### PR TITLE
Add variable rename logic to puf-csv-processing.py script

### DIFF
--- a/final prep/puf-cps-processing.py
+++ b/final prep/puf-cps-processing.py
@@ -1,47 +1,106 @@
-# The recid (key) for each record is not unique after CPS match
-# because 1) original PUF records were split in some cases
-# 2) non-filers were added
+"""
+puf-cps-processing.py transforms puf-cps.csv into final puf.csv file.
 
-# This script fixes the recid issue by
-# 1) adding a digit at the end of recid for all original PUF records
-#      - if no duplicates, add zero
-#      - otherwise, differentiate duplicates by numbering them with increment integers starting from zero
-# 2) setting recid for all non-filers (4000000 - 4005693)
+COMMAND-LINE USAGE: python puf-cps-processing.py
+
+This script transforms the raw csv file in several ways as described below.
+"""
+# CODING-STYLE CHECKS:
+# pep8 --ignore=E402 puf-cps-processing.py
+# pylint --disable=locally-disabled puf-cps-processing.py
+# (when importing numpy, add "--extension-pkg-whitelist=numpy" pylint option)
+
+# disable pylint warning about script name having dashes instead of underscores
+# pylint: disable=invalid-name
 
 
-
+import sys
 import pandas
 
-# import the old CPS matched PUF
-data = pandas.read_csv("cps-puf.csv")
 
-# sort all the records based on old recid
-sorted_dta = data.sort(columns='recid')
+def main():
+    """
+    Contains all the logic of the puf-cps-processing.py script.
+    """
 
-# count how many duplicates each old recid has
-# and save the dup count for each record
-seq = sorted_dta.index
-length = len(sorted_dta['recid'])
-count = [0 for x in range(length)]
-for index in range(1, length):
-    num = seq[index]
-    previous = seq[index-1]
-    if sorted_dta['recid'][num] == sorted_dta['recid'][previous]:
-        count[num] = count[previous]+1
+    # (*) Read unprocessed puf-cps.csv file into a Pandas Dataframe
+    data = pandas.read_csv('cps-puf.csv')
 
 
-# adding the ending digit for filers and non-filers
-# with the dup count
-new_recid = [0 for x in range(length)]
-for index in range(0, length):
-    if data['recid'][index] == 0:
-        new_recid[index] = 4000000 + count[index]
-    else:
-        new_recid[index] = data['recid'][index] * 10 + count[index]
+    # (A) Make recid variable be a unique integer key:
+    #     The recid (key) for each record is not unique after CPS match
+    #     because (1) original SOI PUF records were split in some cases,
+    #     and (2) non-filers were added from the CPS.
+    #     This problem is fixed by (1) adding a digit at the end of recid
+    #     for all original SOI PUF records (if no duplicates, add zero;
+    #     otherwise, differentiate duplicates by numbering them with
+    #     increment integers starting from zero), and (2) setting recid for
+    #     all CPS non-filers to integers beginning with 4000000.
 
-# replace the old recid with the new one
-data['recid'] = new_recid
-data.to_csv('puf.csv', index=False)
+    # sort all the records based on old recid
+    sorted_dta = data.sort(columns='recid')
+
+    # count how many duplicates each old recid has
+    # and save the dup count for each record
+    seq = sorted_dta.index
+    length = len(sorted_dta['recid'])
+    count = [0 for _ in range(length)]
+    for index in range(1, length):
+        num = seq[index]
+        previous = seq[index - 1]
+        if sorted_dta['recid'][num] == sorted_dta['recid'][previous]:
+            count[num] = count[previous] + 1
+
+    # adding the ending digit for filers and non-filers with the dup count
+    new_recid = [0 for _ in range(length)]
+    for index in range(0, length):
+        if data['recid'][index] == 0:
+            new_recid[index] = 4000000 + count[index]
+        else:
+            new_recid[index] = data['recid'][index] * 10 + count[index]
+
+    # replace the old recid with the new one
+    data['recid'] = new_recid
+
+    # (B) Make several variable names be uppercase as in SOI PUF:
+    renames = {
+        'agir1': 'AGIR1',
+        'dsi': 'DSI',
+        'efi': 'EFI',
+        'eic': 'EIC',
+        'elect': 'ELECT',
+        'fded': 'FDED',
+        'flpdyr': 'FLPDYR',
+        'flpdmo': 'FLPDMO',
+        'ie': 'IE',
+        'mars': 'MARS',
+        'midr': 'MIDR',
+        'prep': 'PREP',
+        'schb': 'SCHB',
+        'schcf': 'SCHCF',
+        'sche': 'SCHE',
+        'tform': 'TFORM',
+        'txst': 'TXST',
+        'xfpt': 'XFPT',
+        'xfst': 'XFST',
+        'xocah': 'XOCAH',
+        'xocawh': 'XOCAWH',
+        'xoodep': 'XOODEP',
+        'xopar': 'XOPAR',
+        'xtot': 'XTOT',
+        'recid': 'RECID',
+        'wsamp': 'WSAMP',
+        'txrt': 'TXRT',
+        'agerange': 'AGERANGE',
+    }
+    data = data.rename(columns=renames)
+
+    # (*) Write processed data to the final puf.csv file
+    data.to_csv('puf.csv', index=False)
+
+    return 0
+# end of main function code
 
 
-
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Objective is to use uppercase variable names in all cases where uppercase is used in Tax-Calculator code.  This is the second step in resolving Tax-Calculator issue 425 and is needed by a Tax-Calculator pull request being prepared by Sean Wang.

@Amy-Xu will you please test to make sure this does what it is supposed to do?
I can't test because I don't have a copy of the puf-cps.csv raw input file.
Or, if you want, send me a puf-cps.csv file and I'll be happy to do the testing.

If you want to do the testing:
(a) If there is a problem, let me know what it is and I can fix it.
or
(b) If all is OK, please use it to generate a new puf.csv (and distribute it to the development team) and then merge the revised script into the taxdata master branch.

Either way, thanks for the help.