### PR TITLE
Smooth age distribution

### DIFF
--- a/final prep/puf-cps-processing.py
+++ b/final prep/puf-cps-processing.py
@@ -102,6 +102,8 @@ def age_consistency(data):
     Construct age_head and age_spouse from agerange if available;
     otherwise use CPS values of age_head and age_spouse.
     """
+    # set random-number-generator seed so that always get same random_integers
+    np.random.seed(seed=123456789)
     # generate random integers to smooth age distribution in agerange
     shape = data['age_head'].shape
     agefuzz8 = np.random.random_integers(0, 8, size=shape)

--- a/final prep/puf-cps-processing.py
+++ b/final prep/puf-cps-processing.py
@@ -102,14 +102,100 @@ def age_consistency(data):
     Construct age_head and age_spouse from agerange if available;
     otherwise use CPS values of age_head and age_spouse.
     """
+    # generate random integers to smooth age distribution in agerange
+    shape = data['age_head'].shape
+    agefuzz8 = np.random.random_integers(0, 8, size=shape)
+    agefuzz9 = np.random.random_integers(0, 9, size=shape)
+    agefuzz10 = np.random.random_integers(0, 10, size=shape)
+    agefuzz15 = np.random.random_integers(0, 15, size=shape)
+
+    # assign age_head using agerange midpoint or CPS age if agerange absent
     data['age_head'] = np.where(data['agerange'] == 0,
                                 data['age_head'],
                                 (data['agerange'] + 1 - data['dsi']) * 10)
 
+    # smooth the agerange-based age_head within each agerange
+    data['age_head'] = np.where(np.logical_and(data['agerange'] == 1,
+                                               data['dsi'] == 0),
+                                data['age_head'] - 3 + agefuzz9,
+                                data['age_head'])
+    data['age_head'] = np.where(np.logical_and(data['agerange'] == 2,
+                                               data['dsi'] == 0),
+                                data['age_head'] - 4 + agefuzz9,
+                                data['age_head'])
+    data['age_head'] = np.where(np.logical_and(data['agerange'] == 3,
+                                               data['dsi'] == 0),
+                                data['age_head'] - 5 + agefuzz10,
+                                data['age_head'])
+    data['age_head'] = np.where(np.logical_and(data['agerange'] == 4,
+                                               data['dsi'] == 0),
+                                data['age_head'] - 5 + agefuzz10,
+                                data['age_head'])
+    data['age_head'] = np.where(np.logical_and(data['agerange'] == 5,
+                                               data['dsi'] == 0),
+                                data['age_head'] - 5 + agefuzz10,
+                                data['age_head'])
+    data['age_head'] = np.where(np.logical_and(data['agerange'] == 6,
+                                               data['dsi'] == 0),
+                                data['age_head'] - 5 + agefuzz15,
+                                data['age_head'])
+    data['age_head'] = np.where(np.logical_and(data['agerange'] == 1,
+                                               data['dsi'] == 1),
+                                data['age_head'] - 0 + agefuzz8,
+                                data['age_head'])
+    data['age_head'] = np.where(np.logical_and(data['agerange'] == 2,
+                                               data['dsi'] == 1),
+                                data['age_head'] - 2 + agefuzz8,
+                                data['age_head'])
+    data['age_head'] = np.where(np.logical_and(data['agerange'] == 3,
+                                               data['dsi'] == 1),
+                                data['age_head'] - 4 + agefuzz10,
+                                data['age_head'])
+
+    # assign age_spouse using agerange midpoint or CPS age if agerange absent
     data['age_spouse'] = np.where(data['agerange'] == 0,
                                   data['age_spouse'],
                                   (data['agerange'] + 1 - data['dsi']) * 10)
 
+    # smooth the agerange-based age_spouse within each agerange
+    data['age_spouse'] = np.where(np.logical_and(data['agerange'] == 1,
+                                                 data['dsi'] == 0),
+                                  data['age_spouse'] - 3 + agefuzz9,
+                                  data['age_spouse'])
+    data['age_spouse'] = np.where(np.logical_and(data['agerange'] == 2,
+                                                 data['dsi'] == 0),
+                                  data['age_spouse'] - 4 + agefuzz9,
+                                  data['age_spouse'])
+    data['age_spouse'] = np.where(np.logical_and(data['agerange'] == 3,
+                                                 data['dsi'] == 0),
+                                  data['age_spouse'] - 5 + agefuzz10,
+                                  data['age_spouse'])
+    data['age_spouse'] = np.where(np.logical_and(data['agerange'] == 4,
+                                                 data['dsi'] == 0),
+                                  data['age_spouse'] - 5 + agefuzz10,
+                                  data['age_spouse'])
+    data['age_spouse'] = np.where(np.logical_and(data['agerange'] == 5,
+                                                 data['dsi'] == 0),
+                                  data['age_spouse'] - 5 + agefuzz10,
+                                  data['age_spouse'])
+    data['age_spouse'] = np.where(np.logical_and(data['agerange'] == 6,
+                                                 data['dsi'] == 0),
+                                  data['age_spouse'] - 5 + agefuzz15,
+                                  data['age_spouse'])
+    data['age_spouse'] = np.where(np.logical_and(data['agerange'] == 1,
+                                                 data['dsi'] == 1),
+                                  data['age_spouse'] - 0 + agefuzz8,
+                                  data['age_spouse'])
+    data['age_spouse'] = np.where(np.logical_and(data['agerange'] == 2,
+                                                 data['dsi'] == 1),
+                                  data['age_spouse'] - 2 + agefuzz8,
+                                  data['age_spouse'])
+    data['age_spouse'] = np.where(np.logical_and(data['agerange'] == 3,
+                                                 data['dsi'] == 1),
+                                  data['age_spouse'] - 4 + agefuzz10,
+                                  data['age_spouse'])
+
+    # convert any zero ages to age one
     data['age_head'] = np.where(data['age_head'] == 0,
                                 1, data['age_head'])
     data['age_spouse'] = np.where(data['age_spouse'] == 0,


### PR DESCRIPTION
This pull request attempts to resolve issue #17 by spreading the filing units in an agerange across all the ages in that agerange (rather than placing them all at one age near the center of the agerange).

Using the `eitc_reform.py` script shown below, the following results are generated for the ten-year period from 2017-2026.  These results replicate Sean's finding that when using the current version of the `puf.csv` file, the EITC reform is estimated to cost $45.1 billion over the ten years.  But if we switch to the `puf.csv` file generated by this pull request, the cost rises to $95.5 billion.  So, we have gone from being significantly below the JCT estimate of $71.6 billion to being significantly above the JCT estimate.
```
$ cd tax-calculator

$ cp ../tax-calculator-data/puf-2016-04-25.csv ./puf.csv

$ python eitc_reform.py 
You loaded data for 2009.
Your data have been extrapolated to 2013.
You loaded data for 2009.
Your data have been extrapolated to 2013.
REV1= 18705.247
REV2= 18660.121
REFORM-REV-DIFF= -45.125

$ cp ../tax-calculator-data/puf-fixed.csv ./puf.csv

$ python eitc_reform.py 
You loaded data for 2009.
Your data have been extrapolated to 2013.
You loaded data for 2009.
Your data have been extrapolated to 2013.
REV1= 18694.342
REV2= 18598.842
REFORM-REV-DIFF= -95.501
```

Here is the script that computes the ten-year reform revenue estimates:
```
from taxcalc import Policy, Records, Calculator

ppo1 = Policy()
calc1 = Calculator(policy=ppo1, records=Records())
calc1.advance_to_year(2016)

ppo2 = Policy()
reform = {
    2017: {'_EITC_rt': [[0.153, 0.3400, 0.4000, 0.4500]],
           '_EITC_prt': [[0.153, 0.1598, 0.2106, 0.2106]],
           '_EITC_c': [[1022, 3418.5355, 5647.222, 6353.6315]],
           '_EITC_ps': [[11500, 18435.565, 18435.565, 18435.56]],
           '_EITC_MinEligAge': [21],
           '_EITC_MaxEligAge': [66]}
}
ppo2.implement_reform(reform)
calc2 = Calculator(policy=ppo2, records=Records())
calc2.advance_to_year(2016)

billion = 1.0E-9
iitax1 = list()
iitrev1 = 0.0
iitax2 = list()
iitrev2 = 0.0
for _ in range(10):
  calc1.increment_year()
  calc1.calc_all()
  rev1 = (calc1.records._iitax * calc1.records.s006).sum() * billion
  iitax1.append(rev1)
  iitrev1 += rev1
  calc2.increment_year()
  calc2.calc_all()
  rev2 = (calc2.records._iitax * calc2.records.s006).sum() * billion
  iitax2.append(rev2)
  iitrev2 += rev2

# print iitax1
print 'REV1= {:.3f}'.format(iitrev1)
# print iitax2
print 'REV2= {:.3f}'.format(iitrev2)
print 'REFORM-REV-DIFF= {:.3f}'.format(iitrev2 - iitrev1)
```

@MattHJensen @Amy-Xu 