### PR TITLE
Fill nan values with zeros in CPS file

### DIFF
--- a/CPS File Prep/cps-processing.py
+++ b/CPS File Prep/cps-processing.py
@@ -152,6 +152,7 @@ for item in var_list:
     if item not in USABLE_READ_VARS:
         drop_vars.append(item)
 data.drop(drop_vars, axis=1, inplace=True)
+data.fillna(0, inplace=True)
 
 # Write processed file to a CSV
 data.to_csv('cps.csv', index=False)


### PR DESCRIPTION
This PR adds one line of code to `cps-processing.py` that will fill `NaN` values with zeros. Without this, any calculations involving a variable that has `NaN` values will result in `NaN`. 
@Amy-Xu 