### PR TITLE
Rename execute as makecsv and add copycsv bash script

### DIFF
--- a/copycsv
+++ b/copycsv
@@ -1,0 +1,94 @@
+#!/bin/bash
+# copies CSV files produced by makecsv in the specified taxcalc directory tree
+
+function usage {
+    echo "USAGE: ./copycsv DATATYPE TAXCALCDIR [dryrun]"
+    echo "       where DATATYPE can be puf or cps"
+    echo "         and TAXCALCDIR is path to Tax-Calculator taxcalc directory"
+    echo "             (TAXCALCDIR must end with a / character)"
+    echo "         and dryrun is optional signal to skip the CSV copying"
+    echo "       Note: run ./copycsv in top-level taxdata directory"
+    exit 1
+}
+
+function copyifdiff {
+    # FUNCTION ARGUMENTS: $1=FILENAME $2=SRCPATH $3=DSTPATH $4=DRYRUN
+    if [ -f $3 ]; then
+        diff --brief $2 $3 >/dev/null
+        ISDIFF=$?
+        if [ $ISDIFF -eq 0 ]; then
+            echo "NO DIFFERENCES IN $1 ==> FILE COPY IS UNNECESSARY"
+        else
+            echo "SOME DIFFERNCES IN $1 ==> FILE COPY IS NECESSARY"
+        fi
+    else
+        echo "TAXCALCDIR FILE $1 DOES NOT EXIST ==> COPY MAY BE INEFFECTIVE"
+        ISDIFF=1
+    fi
+    if [ $ISDIFF -eq 1 ] && [ $4 -eq 0 ]; then
+        cp $2 $3
+        echo "COPIED $2 TO $3"
+    fi
+}
+
+# process command-line arguments
+if [ $# -lt 2 ] || [ $# -gt 3 ]; then
+    echo "ERROR: number of command-line arguments is not two or three"
+    usage
+fi
+DTYPE=$1
+if [ $DTYPE != "puf" ] && [ $DTYPE != "cps" ]; then
+    echo "ERROR: DATATYPE is neither puf nor cps"
+    usage
+fi
+TAXCALCDIR=$2
+if [[ ! $TAXCALCDIR = */ ]]; then
+    echo "ERROR: $TAXCALCDIR does not end in /"
+    usage
+fi
+if [ ! -d $TAXCALCDIR ]; then
+    echo "ERROR: $TAXCALCDIR is not a directory"
+    usage
+fi
+if [ $# -eq 3 ]; then
+    if [ $3 == "dryrun" ]; then
+        DRYRUN=1
+    else
+        echo "ERROR: unknown option $3"
+        usage
+    fi
+else
+    DRYRUN=0
+fi
+
+# TODO TEMPORARY CODE BELOW
+if [ $DTYPE == "cps" ]; then
+    echo "ERROR: DATATYPE cannot be cps yet"
+    usage
+fi
+# TODO TEMPORARY CODE ABOVE
+
+# copy $DTYPE_data/$DTYPE.csv file if different
+TAXDATADIR=$DTYPE"_data/"
+FILENAME=$DTYPE".csv"
+copyifdiff $FILENAME $TAXDATADIR$FILENAME $TAXCALCDIR$FILENAME $DRYRUN
+
+# copy stage1/growfactors.csv file if different
+TAXDATADIR="stage1/"
+FILENAME="growfactors.csv"
+copyifdiff $FILENAME $TAXDATADIR$FILENAME $TAXCALCDIR$FILENAME $DRYRUN
+
+# copy $DTYPE_stage2/$DTYPE_weights.csv file if different
+TAXDATADIR=$DTYPE"_stage2/"
+FILENAME=$DTYPE"_weights.csv"
+copyifdiff $FILENAME $TAXDATADIR$FILENAME $TAXCALCDIR$FILENAME $DRYRUN
+
+# TODO FUTURE CODE BELOW
+# copy $DTYPE_stage3/$DTYPE_ratios.csv file if different
+TAXDATADIR=$DTYPE"_stage3/"
+FILENAME=$DTYPE"_ratios.csv"
+#######copyifdiff $FILENAME $TAXDATADIR$FILENAME $TAXCALCDIR$FILENAME $DRYRUN
+# TODO FUTURE CODE ABOVE
+
+exit 0
+

--- a/makecsv
+++ b/makecsv
@@ -1,13 +1,11 @@
 #!/bin/bash
-# execute runs taxdata Python scripts through the specified last stage
-# USAGE: ./exec  puf|cps  1|2|3
-# (run this command in the top-level taxdata directory)
+# executes taxdata Python scripts through the specified last stage
 
 function usage {
-    echo "USAGE: ./execute DATATYPE LASTSTAGE"
+    echo "USAGE: ./makecsv DATATYPE LASTSTAGE"
     echo "       where DATATYPE can be puf or cps"
     echo "         and LASTSTAGE can be 1 or 2 or 3"
-    echo "       Note: run ./execute in top-level taxdata directory"
+    echo "       Note: run ./makecsv in top-level taxdata directory"
     echo "Execution time will be roughly one hour when LASTSTAGE is 2 or 3" 
     exit 1
 }


### PR DESCRIPTION
Add `copycsv` script that copies CSV-formatted files created by the `makecsv` bash script to a specified tax-calculator/taxcalc directory.  The `copycsv` script has a dryrun option that show what will happen but does not actually do the file copying.

@MattHJensen @Amy-Xu @andersonfrailey 