### PR TITLE
Replace e20500 with g20500

### DIFF
--- a/puf_data/finalprep.py
+++ b/puf_data/finalprep.py
@@ -431,9 +431,10 @@ def replace_20500(data):
     Replace e20500, net casualty losses, with g20500, gross casualty losses
     (gross loss values less than 10% AGI are unknown and assumed to be zero)
     """
-    data['g20500'] = np.where(data.e20500 > 0.,
-                              data.e20500 + 0.10 * np.maximum(0., data.e00100),
-                              0.)
+    gross = np.where(data.e20500 > 0.,
+                     data.e20500 + 0.10 * np.maximum(0., data.e00100),
+                     0.)
+    data['g20500'] = np.int_(gross.round())
     return data
 
 


### PR DESCRIPTION
This pull request replaces net casualty losses (`e20500`) with an estimate of gross casualty losses (`g20500`).  The changes in this pull request and in a corresponding Tax-Calculator pull request fix the problem identified in [Tax-Calculator issue 1425](https://github.com/open-source-economics/Tax-Calculator/issues/1425).

@MattHJensen @Amy-Xu @andersonfrailey @hdoupe 