### PR TITLE
Comment out benefit data logic

### DIFF
--- a/puf_data/finalprep.py
+++ b/puf_data/finalprep.py
@@ -286,7 +286,8 @@ def remove_unused_variables(data):
         'vbp',
         'vbs',
         'wt']
-    data = data.drop(NEW_POST_PR83_UNUSED_READ_VARS, 1)
+    # data = data.drop(NEW_POST_PR83_UNUSED_READ_VARS, 1)
+
     data = data.fillna(value=0)
     return data
 
@@ -299,7 +300,7 @@ def remove_benefits_variables(data):
         'ssi', 'ssip', 'ssis', 'ssi_participation',
         'snap', 'snapp', 'snaps', 'snap_participation',
         'medicarex', 'medicarexp', 'medicarexs']
-    data = data.drop(BENEFIT_VARS, 1)
+    # data = data.drop(BENEFIT_VARS, 1)
     return data
 
 


### PR DESCRIPTION
Implement item 4 of issue #92 plan specified by @andersonfrailey.
Item 4 in issue #92 is:
> For now, NEW_POST_PR83_UNUSED_READ_VARS and the remove_benefits_variables functions are not needed. This initial iteration of the matching program does not add the additional benefits related variables that made those necessary. This will change when we do add them though, so simply commenting out the code that runs those functions would probably be best to avoid having to add it all back down the road.
