### PR TITLE
Add gzip -f option to eliminate interactive prompts to overwrite old .gz file

### DIFF
--- a/cps_data/finalprep.py
+++ b/cps_data/finalprep.py
@@ -92,7 +92,7 @@ def main():
     data = data.fillna(0.)
     print 'Exporting...'
     data.to_csv('cps.csv', index=False)
-    subprocess.check_call(["gzip", "-n", "cps.csv"])
+    subprocess.check_call(["gzip", "-nf", "cps.csv"])
 
 
 def deduction_limits(data):

--- a/cps_stage2/finalprep.py
+++ b/cps_stage2/finalprep.py
@@ -6,4 +6,4 @@ weights = pd.read_csv('cps_weights_raw.csv.gz', compression='gzip')
 weights *= 100.
 weights = weights.round(0).astype('int64')
 weights.to_csv('cps_weights.csv', index=False)
-subprocess.check_call(['gzip', '-n', 'cps_weights.csv'])
+subprocess.check_call(['gzip', '-nf', 'cps_weights.csv'])


### PR DESCRIPTION
Without the added -f option, the `finalprep.py` scripts in the `cps_stage2` and `cps_data` directories will not work smoothly in an unattended bash script.  These changes do not affect taxdata logic or results.