### PR TITLE
Add h_seq and ffpos Variables

### DIFF
--- a/cps_data/finalprep.py
+++ b/cps_data/finalprep.py
@@ -48,12 +48,12 @@ def main():
         'BLIND_HEAD': 'blind_head',
         'BLIND_SPOUSE': 'blind_spouse',
         'HMIE': 'e19200',
-        # 'SSI': 'ssi_ben',
-        # 'VB': 'vet_ben',
-        # 'MEDICARE': 'mcare_ben',
-        # 'MEDICAID': 'mcaid_ben',
-        # 'SS': 'ss_ben',
-        # 'SNAP': 'snap_ben',
+        'SSI': 'ssi_ben',
+        'vb_ben': 'vet_ben',
+        'medicare_ben': 'mcare_ben',
+        'medicaid_ben': 'mcaid_ben',
+        'SS': 'ss_ben',
+        'SNAP': 'snap_ben',
         'SLTX': 'e18400',
         'XHID': 'h_seq',
         'XFID': 'ffpos'
@@ -202,9 +202,7 @@ def drop_vars(data):
         'vet_ben', 'mcare_ben', 'mcaid_ben', 'ss_ben', 'other_ben',
         'total_ben', 'h_seq', 'ffpos'
     ]
-    # for i in range(1, 16):
-    #    useable_vars.append('SSI_VAL{}'.format(str(i)))
-    #    useable_vars.append('SSI_PROB{}'.format(str(i)))
+
     drop_vars = []
     for item in data.columns:
         if item not in useable_vars:

--- a/cps_data/finalprep.py
+++ b/cps_data/finalprep.py
@@ -54,7 +54,9 @@ def main():
         # 'MEDICAID': 'mcaid_ben',
         # 'SS': 'ss_ben',
         # 'SNAP': 'snap_ben',
-        'SLTX': 'e18400'
+        'SLTX': 'e18400',
+        'XHID': 'h_seq',
+        'XFID': 'ffpos'
     }
     data = data.rename(columns=renames)
     data['MARS'] = np.where(data.JS == 3, 4, data.JS)
@@ -197,7 +199,8 @@ def drop_vars(data):
         'e87530', 'elderly_dependent', 'f2441', 'f6251', 'filer', 'n24',
         'nu05', 'nu13', 'nu18', 'n1821', 'n21', 'p08000', 'p22250', 'p23250',
         'p25470', 'p87521', 's006', 'e03210', 'ssi_ben', 'snap_ben',
-        'vet_ben', 'mcare_ben', 'mcaid_ben', 'ss_ben', 'other_ben', 'total_ben'
+        'vet_ben', 'mcare_ben', 'mcaid_ben', 'ss_ben', 'other_ben',
+        'total_ben', 'h_seq', 'ffpos'
     ]
     # for i in range(1, 16):
     #    useable_vars.append('SSI_VAL{}'.format(str(i)))


### PR DESCRIPTION
This PR completes a request from @MattHJensen to add the household sequence and the unique family identifier variables, `h_seq` and `ffpos`, respectively, to the CPS file. They are names in accordance with the [NBER](http://www.nber.org/cps/cpsmar2014.pdf) documentation. Using the two in combination, you can identify individual families in the CPS.

For example, you may have a household with `h_seq == 1` that contains two families. `ffpos` for the two families will be 1 and 2.

A corresponding Tax-Calculator PR is forth coming.