### PR TITLE
PUF Bug Fixes

### DIFF
--- a/puf_data/StatMatch/Matching/add_cps_vars.py
+++ b/puf_data/StatMatch/Matching/add_cps_vars.py
@@ -11,7 +11,7 @@ import pandas as pd
 def add_cps(cps_recs, match, puffile):
     # cps_recs = pd.read_csv('cpsrets14.csv')
     cpsfile = cps_recs.filter(regex='jcps\d{1,2}$|icps\d{1}$|jcps100|cpsseq|' +
-                                    'nu\d{1,2}|nu18_dep|n1821|n21|' +
+                                    'nu\d{1,2}|nu18_dep|n1820|n21|' +
                                     'elderly_dependent|wasp|wass|xstate')
     # cpsfile = cps_recs
     # match = pd.read_csv('match.csv')

--- a/puf_data/StatMatch/Matching/add_nonfilers.py
+++ b/puf_data/StatMatch/Matching/add_nonfilers.py
@@ -5,6 +5,7 @@ Output file: prod2009_v2.csv
 """
 
 import pandas as pd
+import copy
 
 
 def add_nonfiler(cpsrets, nonfiler):
@@ -29,9 +30,12 @@ def add_nonfiler(cpsrets, nonfiler):
     socsec = nonfiler['socsec']
     wt = nonfiler['wt']
 
-    nonfiler = nonfiler.filter(regex='jcps\d{1,2}$|icps\d{1}$|jcps100|' +
-                                     'cpsseq|nu\d{1,2}|nu18_dep|n1821|n21|' +
-                                     'elderly_dependent|wasp|wass|xstate')
+    nonfiler = copy.deepcopy(nonfiler.filter(regex='jcps\d{1,2}$|icps\d{1}$|' +
+                                                   'jcps100| cpsseq|' +
+                                                   'nu\d{1,2}|nu18_dep|' +
+                                                   'n1820|n21|' +
+                                                   'elderly_dependent|wasp|' +
+                                                   'wass|xstate'))
 
     nonfiler['filer'] = 0
     nonfiler['soiseq'] = 0
@@ -244,7 +248,7 @@ def add_nonfiler(cpsrets, nonfiler):
     nonfiler['s27860'] = 0
     nonfiler['p27895'] = 0
     nonfiler['p87482'] = 0
-    nonfiler['p87521'] = 0
+    nonfiler['e87521'] = 0
     nonfiler['e87530'] = 0
     nonfiler['e87550'] = 0
     nonfiler['p86421'] = 0

--- a/puf_data/StatMatch/Matching/add_nonfilers.py
+++ b/puf_data/StatMatch/Matching/add_nonfilers.py
@@ -201,7 +201,6 @@ def add_nonfiler(cpsrets, nonfiler):
     nonfiler['e24570'] = 0
     nonfiler['p25350'] = 0
     nonfiler['p25380'] = 0
-    nonfiler['p25470'] = 0
     nonfiler['p25700'] = 0
     nonfiler['e25820'] = 0
     nonfiler['e25850'] = 0

--- a/puf_data/finalprep.py
+++ b/puf_data/finalprep.py
@@ -65,6 +65,8 @@ def main():
     if not BENPUF:
         data = remove_benefits_variables(data)
 
+    # Convert data to integers
+    data = data.round(0).astype('int64')
     # - Write processed data to the final CSV-formatted file:
     if BENPUF:
         data.to_csv('benpuf.csv', index=False)
@@ -238,7 +240,7 @@ def remove_unused_variables(data):
         'e26100', 'e05200', 'e87875', 'e82200', 'e25860', 'e07220',
         'e11070', 'e11550', 'e11580', 'p87482', 'e20500', 'FDED',
         'e11900', 'e18600', 'e25960', 'e15100', 'p27895', 'e12200',
-        'nu18_dep', 'e87521', 'e11601', 'e11603', 'e11602', 'e25550', 'f8867',
+        'nu18_dep', 'e11601', 'e11603', 'e11602', 'e25550', 'f8867',
         'f8949']
     MORE_UNUSED_READ_VARS = [
         'jcps88',


### PR DESCRIPTION
This PR fixes some of the bugs created in PR #114. Namely, it includes `n1820` in the final `puf.csv` file, converts all of the PUF columns to `int64` types, and replaces `p87521` with `e87521`.

In `add_nonfilers.py`, I modified the code to use a deepcopy of the non filer data frame to address a Pandas warning message. It doesn't affect the results in any way.

cc @martinholmer 