### PR TITLE
Fix Non-Filer Pensions

### DIFF
--- a/puf_data/StatMatch/Matching/add_nonfilers.py
+++ b/puf_data/StatMatch/Matching/add_nonfilers.py
@@ -101,8 +101,7 @@ def add_nonfiler(cpsrets, nonfiler):
     nonfiler['e01200'] = 0
     nonfiler['e01400'] = 0
     nonfiler['e01500'] = pensions
-    taxable_pensions = cpsrets.e01700.sum() / cpsrets.e01500.sum()
-    nonfiler['e01700'] = pensions * taxable_pensions
+    nonfiler['e01700'] = pensions
     nonfiler['e02000'] = rents
     nonfiler['e02100'] = fil
     nonfiler['e02300'] = ucomp

--- a/puf_data/StatMatch/Matching/add_nonfilers.py
+++ b/puf_data/StatMatch/Matching/add_nonfilers.py
@@ -100,8 +100,8 @@ def add_nonfiler(cpsrets, nonfiler):
     nonfiler['e01100'] = 0
     nonfiler['e01200'] = 0
     nonfiler['e01400'] = 0
-    nonfiler['e01500'] = 0
-    nonfiler['e01700'] = pensions
+    nonfiler['e01500'] = pensions
+    nonfiler['e01700'] = pensions * 0.1656
     nonfiler['e02000'] = rents
     nonfiler['e02100'] = fil
     nonfiler['e02300'] = ucomp

--- a/puf_data/StatMatch/Matching/add_nonfilers.py
+++ b/puf_data/StatMatch/Matching/add_nonfilers.py
@@ -101,7 +101,8 @@ def add_nonfiler(cpsrets, nonfiler):
     nonfiler['e01200'] = 0
     nonfiler['e01400'] = 0
     nonfiler['e01500'] = pensions
-    nonfiler['e01700'] = pensions * 0.1656
+    taxable_pensions = cpsrets.e01700.sum() / cpsrets.e01500.sum()
+    nonfiler['e01700'] = pensions * taxable_pensions
     nonfiler['e02000'] = rents
     nonfiler['e02100'] = fil
     nonfiler['e02300'] = ucomp


### PR DESCRIPTION
This PR addresses issue #156. I've modified the `add_nonfilers` script so that pension income is assigned to `e01500` rather than `e01700`.   And then it is assumed that among non-filers all pension income is taxable.