### PR TITLE
Fix Age Variables

### DIFF
--- a/cps_data/cps_file_doc.md
+++ b/cps_data/cps_file_doc.md
@@ -148,9 +148,9 @@ The student loan interest deduction is capped at $2,500, and IRA contributions
 are limited at either $6,500 or $5,500 depending on the age of the head of the
 tax unit.
 
-We then count the number of dependents under 5 and 13 or over 65 years old.
-Finally, the number of children qualified for the child tax credit, childcare
-credit, and earned income credit are counted for each tax unit.
+We then count the number of dependents under 5 years old, under 13, and 65 or
+older. Finally, the number of children qualified for the child tax credit,
+childcare credit, and earned income credit are counted for each tax unit.
 
 The last step in the final preparations is adjusting the distribution of interest
 income, ordinary and qualified dividends, and self-employment income using a

--- a/cps_data/finalprep.py
+++ b/cps_data/finalprep.py
@@ -159,28 +159,28 @@ def deduction_limits(data):
 def add_dependents(data):
     # Count number of dependents under 13
     # Max of four to match PUF version of nu13
-    age1 = np.where((data.ICPS03 > 0) & (data.ICPS03 <= 13), 1, 0)
-    age2 = np.where((data.ICPS04 > 0) & (data.ICPS04 <= 13), 1, 0)
-    age3 = np.where((data.ICPS05 > 0) & (data.ICPS05 <= 13), 1, 0)
-    age4 = np.where((data.ICPS06 > 0) & (data.ICPS06 <= 13), 1, 0)
+    age1 = np.where((data.ICPS03 > 0) & (data.ICPS03 < 13), 1, 0)
+    age2 = np.where((data.ICPS04 > 0) & (data.ICPS04 < 13), 1, 0)
+    age3 = np.where((data.ICPS05 > 0) & (data.ICPS05 < 13), 1, 0)
+    age4 = np.where((data.ICPS06 > 0) & (data.ICPS06 < 13), 1, 0)
     nu13 = age1 + age2 + age3 + age4
     data['nu13'] = nu13
 
     # Count number of dependents under 5
-    age1 = np.where((data.ICPS03 > 0) & (data.ICPS03 <= 5), 1, 0)
-    age2 = np.where((data.ICPS04 > 0) & (data.ICPS04 <= 5), 1, 0)
-    age3 = np.where((data.ICPS05 > 0) & (data.ICPS05 <= 5), 1, 0)
-    age4 = np.where((data.ICPS06 > 0) & (data.ICPS06 <= 5), 1, 0)
-    age5 = np.where((data.ICPS07 > 0) & (data.ICPS06 <= 5), 1, 0)
+    age1 = np.where((data.ICPS03 > 0) & (data.ICPS03 < 5), 1, 0)
+    age2 = np.where((data.ICPS04 > 0) & (data.ICPS04 < 5), 1, 0)
+    age3 = np.where((data.ICPS05 > 0) & (data.ICPS05 < 5), 1, 0)
+    age4 = np.where((data.ICPS06 > 0) & (data.ICPS06 < 5), 1, 0)
+    age5 = np.where((data.ICPS07 > 0) & (data.ICPS06 < 5), 1, 0)
     nu05 = age1 + age2 + age3 + age4 + age5
     data['nu05'] = nu05
 
     # Count number of children eligible for child tax credit
-    age1 = np.where((data.ICPS03 > 0) & (data.ICPS03 <= 17), 1, 0)
-    age2 = np.where((data.ICPS04 > 0) & (data.ICPS04 <= 17), 1, 0)
-    age3 = np.where((data.ICPS05 > 0) & (data.ICPS05 <= 17), 1, 0)
-    age4 = np.where((data.ICPS06 > 0) & (data.ICPS06 <= 17), 1, 0)
-    age5 = np.where((data.ICPS07) > 0 & (data.ICPS07 <= 17), 1, 0)
+    age1 = np.where((data.ICPS03 > 0) & (data.ICPS03 < 17), 1, 0)
+    age2 = np.where((data.ICPS04 > 0) & (data.ICPS04 < 17), 1, 0)
+    age3 = np.where((data.ICPS05 > 0) & (data.ICPS05 < 17), 1, 0)
+    age4 = np.where((data.ICPS06 > 0) & (data.ICPS06 < 17), 1, 0)
+    age5 = np.where((data.ICPS07) > 0 & (data.ICPS07 < 17), 1, 0)
     n24 = age1 + age2 + age3 + age4 + age5
     data['n24'] = n24
 

--- a/puf_data/StatMatch/Matching/cps_rets.py
+++ b/puf_data/StatMatch/Matching/cps_rets.py
@@ -699,9 +699,9 @@ class Returns(object):
                     dage = individual['a_age']
                     record[('dep' + str(depne))] = house.index(individual)
                     record['depage' + str(depne)] = dage
-                    if individual['a_age'] <= 5:
+                    if individual['a_age'] < 5:
                         record['nu05'] += 1
-                    if individual['a_age'] <= 13:
+                    if individual['a_age'] < 13:
                         record['nu13'] += 1
                     if 0 < individual['a_age'] < 18:
                         record['nu18'] += 1


### PR DESCRIPTION
This PR addresses concerns raised by @MaxGhenis in issue #164. I've corrected the `nu05`, `nu13`, and `n24` variables in the CPS file, as well as modified the scripts to create the PUF. Interestingly, I got the same MD5 output from the PUF after rerunning the scripts with the included modification.

cc @martinholmer 