### PR TITLE
remove sequence column from weights

### DIFF
--- a/cps_stage2/finalprep.py
+++ b/cps_stage2/finalprep.py
@@ -3,6 +3,7 @@ import subprocess
 
 
 weights = pd.read_csv('cps_weights_raw.csv.gz', compression='gzip')
+weights = weights.drop('SEQUENCE', axis=1)
 weights *= 100.
 weights = weights.round(0).astype('int64')
 weights.to_csv('cps_weights.csv', index=False)


### PR DESCRIPTION
This PR partially resolves issue #176 by removing the `SEQUENCE` column from the final CPS weights file.