### PR TITLE
Move multiplication of weights in final prep - CPS

### DIFF
--- a/cps_data/finalprep.py
+++ b/cps_data/finalprep.py
@@ -68,7 +68,6 @@ def main():
         'F2441': 'f2441'
     }
     data = data.rename(columns=renames)
-    data['s006'] *= 100.
     data['MARS'] = np.where(data.JS == 3, 4, data.JS)
 
     # Use taxpayer and spouse records to get total tax unit earnings and AGI
@@ -133,6 +132,7 @@ def main():
     data['e00200'] = data['e00200p'] + data['e00200s']
     data['e00900'] = data['e00900p'] + data['e00900s']
     data['e02100'] = data['e02100p'] + data['e02100s']
+    data['s006'] *= 100.
     print('Exporting...')
     data.to_csv('cps.csv', index=False)
     subprocess.check_call(["gzip", "-nf", "cps.csv"])


### PR DESCRIPTION
This PR fixes a bug in the CPS final prep scripts introduced in PR #184. In that PR, I added a single line that multiplied the weights in the CPS file by 100 at the very beginning of the script which had negative downstream effects pointed out by @martinholmer in issue #186.

In this PR I've moved the multiplication of the weights to the end of the script, fixing the issues.