### PR TITLE
Fix Charitable Deduction Values

### DIFF
--- a/cps_data/finalprep.py
+++ b/cps_data/finalprep.py
@@ -142,8 +142,9 @@ def deduction_limits(data):
     """
     Apply limits on itemized deductions
     """
+    data['CHARITABLE'] = data['CHARITABLE'].fillna(0.)
     half_agi = data['e00100'] * 0.5
-    charity = np.where(data.CHARITABLE > half_agi, half_agi, data.CHARITABLE)
+    charity = np.maximum(data.CHARITABLE, half_agi)
     # Split charitable contributions into cash and non-cash using ratio in PUF
     cash = 0.82013
     non_cash = 1. - cash

--- a/cps_data/finalprep.py
+++ b/cps_data/finalprep.py
@@ -144,7 +144,8 @@ def deduction_limits(data):
     """
     data['CHARITABLE'] = data['CHARITABLE'].fillna(0.)
     half_agi = data['e00100'] * 0.5
-    charity = np.maximum(data.CHARITABLE, half_agi)
+    charity = np.minimum(data.CHARITABLE, half_agi)
+    charity = np.maximum(charity, 0.)
     # Split charitable contributions into cash and non-cash using ratio in PUF
     cash = 0.82013
     non_cash = 1. - cash


### PR DESCRIPTION
I noticed that some tax units in the CPS had negative charitable deduction values. This PR changes the logic for how we calculate charitable deduction values so that they adhere to the "half of AGI" cap, but will always be at least zero.