### PR TITLE
Change Path for CPS Benefit Extrapolation Weights

### DIFF
--- a/cps_stage3/extrapolation.py
+++ b/cps_stage3/extrapolation.py
@@ -7,7 +7,7 @@ import time
 class Benefits():
     GROWTH_RATES_PATH = 'growth_rates.csv'
     CPS_BENEFIT_PATH = '../cps_data/cps_raw_rename.csv.gz'
-    CPS_WEIGHTS_PATH = '../cps_stage2/cps_weights.csv.gz'
+    CPS_WEIGHTS_PATH = '../cps_stage2/cps_weights_raw.csv.gz'
 
     def __init__(self,
                  growth_rates=GROWTH_RATES_PATH,
@@ -25,7 +25,7 @@ class Benefits():
     def increment_year(self, tol=0.01):
         self.current_year += 1
         print("starting year", self.current_year)
-        WT = self.WT.loc[:, 'WT'+str(self.current_year)] * 0.01
+        WT = self.WT.loc[:, 'WT'+str(self.current_year)]
         for benefit in self.benefit_names:
             participant_targets = getattr(self, "{}_participant_targets".format(benefit))
             benefit_targets = getattr(self, "{}_benefit_targets".format(benefit))

--- a/cps_stage3/test_extrapolation.py
+++ b/cps_stage3/test_extrapolation.py
@@ -10,8 +10,7 @@ import pytest
 from extrapolation import Benefits
 
 
-def test_add_participants(benefit_growth_rates_path, raw_cps_path,
-                          raw_weights_path):
+def test_add_participants():
     """
     Checks
         1. those with benefits still have benefits
@@ -19,10 +18,7 @@ def test_add_participants(benefit_growth_rates_path, raw_cps_path,
     """
     # use medicare since that program needs participants added in 2015
     benefit_names = ["medicare"]
-    ben = Benefits(growth_rates=benefit_growth_rates_path,
-                   cps_benefit=raw_cps_path,
-                   cps_weights=raw_weights_path,
-                   benefit_names=benefit_names)
+    ben = Benefits(benefit_names=benefit_names)
 
     # prepare test data
     recid_ext = pd.concat([ben.benefit_extrapolation.RECID for i in range(15)], axis=1)
@@ -118,8 +114,7 @@ def test_add_participants(benefit_growth_rates_path, raw_cps_path,
         )
 
 
-def test_remove_participants(benefit_growth_rates_path, raw_cps_path,
-                             raw_weights_path):
+def test_remove_participants():
     """
     Checks
         1. those without benefits still do not have benefits
@@ -127,10 +122,7 @@ def test_remove_participants(benefit_growth_rates_path, raw_cps_path,
     """
     # use snap since that program needs participants removed in 2015
     benefit_names = ["snap"]
-    ben = Benefits(growth_rates=benefit_growth_rates_path,
-                   cps_benefit=raw_cps_path,
-                   cps_weights=raw_weights_path,
-                   benefit_names=benefit_names)
+    ben = Benefits(benefit_names=benefit_names)
 
     # prepare test data
     recid_ext = pd.concat([ben.benefit_extrapolation.RECID for i in range(15)], axis=1)

--- a/cps_stage3/test_extrapolation.py
+++ b/cps_stage3/test_extrapolation.py
@@ -10,7 +10,8 @@ import pytest
 from extrapolation import Benefits
 
 
-def test_add_participants():
+def test_add_participants(benefit_growth_rates_path, raw_cps_path,
+                          raw_weights_path):
     """
     Checks
         1. those with benefits still have benefits
@@ -18,7 +19,10 @@ def test_add_participants():
     """
     # use medicare since that program needs participants added in 2015
     benefit_names = ["medicare"]
-    ben = Benefits(benefit_names=benefit_names)
+    ben = Benefits(growth_rates=benefit_growth_rates_path,
+                   cps_benefit=raw_cps_path,
+                   cps_weights=raw_weights_path,
+                   benefit_names=benefit_names)
 
     # prepare test data
     recid_ext = pd.concat([ben.benefit_extrapolation.RECID for i in range(15)], axis=1)
@@ -114,7 +118,8 @@ def test_add_participants():
         )
 
 
-def test_remove_participants():
+def test_remove_participants(benefit_growth_rates_path, raw_cps_path,
+                             raw_weights_path):
     """
     Checks
         1. those without benefits still do not have benefits
@@ -122,7 +127,10 @@ def test_remove_participants():
     """
     # use snap since that program needs participants removed in 2015
     benefit_names = ["snap"]
-    ben = Benefits(benefit_names=benefit_names)
+    ben = Benefits(growth_rates=benefit_growth_rates_path,
+                   cps_benefit=raw_cps_path,
+                   cps_weights=raw_weights_path,
+                   benefit_names=benefit_names)
 
     # prepare test data
     recid_ext = pd.concat([ben.benefit_extrapolation.RECID for i in range(15)], axis=1)


### PR DESCRIPTION
The CPS benefit extrapolation scripts currently read in the cleaned weights and use the `SEQUENCE` column that was dropped in PR #177. This PR updates them to use the raw weights file instead. There is no significant change in extrapolated benefit value.

cc @hdoupe 