### PR TITLE
Use minimal environment.yml file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
 - pandas >=0.22.0
 - bokeh >=0.12.3
 - pytest
-pip:
-- ipython
-- ipykernel
-- cylp==0.7.1
+- pip:
+  - ipython
+  - ipykernel
+  - cylp==0.7.1

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: taxdata-dev
 dependencies:
-- python=2.7.15
+- python>=2.7.14
 - numpy >=1.12.1
 - pandas >=0.22.0
 - bokeh >=0.12.3

--- a/environment.yml
+++ b/environment.yml
@@ -8,4 +8,3 @@ dependencies:
 - pip:
   - ipython
   - ipykernel
-  - cylp=0.7.1

--- a/environment.yml
+++ b/environment.yml
@@ -1,11 +1,11 @@
 name: taxdata-dev
 dependencies:
 - python>=2.7.14
-- numpy >=1.12.1
-- pandas >=0.22.0
+- numpy=1.13.3
+- pandas=0.20.3
 - bokeh >=0.12.3
 - pytest
 - pip:
   - ipython
   - ipykernel
-  - cylp==0.7.1
+  - cylp=0.7.1

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ dependencies:
 - python>=2.7.14
 - numpy=1.13.3
 - pandas=0.20.3
+- scipy=0.18.1
 - bokeh >=0.12.3
 - pytest
 - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -1,66 +1,7 @@
 name: taxdata-dev
-channels:
-- anaconda
-- https://conda.anaconda.org/t/Op-d8036d4f-1ea8-475e-bc39-311eaaddfd86/opensourcepolicycenter
-- anaconda-fusion
-- defaults
 dependencies:
-- appnope=0.1.0=py27hb466136_0
-- backports=1.0=py27hb4f9756_1
-- backports.shutil_get_terminal_size=1.0.0=py27hc9115de_2
-- backports_abc=0.5=py27h6972548_0
-- certifi=2017.7.27.1=py27h482ffc0_0
-- decorator=4.1.2=py27h9f877ea_0
-- enum34=1.1.6=py27hf475452_1
-- ipykernel=4.6.1=py27h1e70a78_0
-- ipython=5.4.1=py27h2b3d779_1
-- ipython_genutils=0.2.0=py27h8b9a179_0
-- jupyter_client=5.1.0=py27hfaf569a_0
-- jupyter_core=4.3.0=py27hd5161ba_0
-- libcxx=4.0.1=h579ed51_0
-- libcxxabi=4.0.1=hebd6815_0
-- libsodium=1.0.13=hba5e272_2
-- pathlib2=2.3.0=py27he09da1e_0
-- pexpect=4.2.1=py27hc4e4961_0
-- pickleshare=0.7.4=py27h37e3d41_0
-- prompt_toolkit=1.0.15=py27h4a7b9c2_0
-- ptyprocess=0.5.2=py27h70f6364_0
-- pygments=2.2.0=py27h1a556bb_0
-- pyzmq=16.0.2=py27he61c07e_2
-- scandir=1.6=py27h97aa1ee_0
-- simplegeneric=0.8.1=py27_1
-- singledispatch=3.4.0.3=py27he22c18d_0
-- ssl_match_hostname=3.5.0.1=py27h8780752_2
-- tornado=4.5.2=py27h29aec9e_0
-- traitlets=4.3.2=py27hcf08151_0
-- wcwidth=0.1.7=py27h817c265_0
-- zeromq=4.2.2=hf974341_2
-- intel-openmp=2018.0.0=h68bdfb3_7
-- libgfortran=3.0.1=h93005f0_2
-- mkl=2018.0.0=h5ef208c_6
-- numpy=1.13.3=py27h62f9060_0
-- openssl=1.0.2l=0
-- pandas=0.20.3=py27_0
-- patsy=0.4.1=py27h40ed276_0
-- pip=9.0.1=py27_1
-- python=2.7.13=0
-- python-dateutil=2.6.1=py27_0
-- pytz=2017.2=py27_0
-- readline=6.2=2
-- scipy=0.18.1=py27h793f721_0
-- setuptools=27.2.0=py27_0
-- six=1.10.0=py27_0
-- sqlite=3.13.0=0
-- statsmodels=0.8.0=py27h6d68dbf_0
-- tk=8.5.18=0
-- wheel=0.29.0=py27_0
-- zlib=1.2.11=0
-- pip:
-  - backports-abc==0.5
-  - backports.shutil-get-terminal-size==1.0.0
-  - backports.ssl-match-hostname==3.5.0.1
-  - cylp==0.7.1
-  - ipython-genutils==0.2.0
-  - jupyter-client==5.1.0
-  - jupyter-core==4.3.0
-  - prompt-toolkit==1.0.15
+- python=2.7.15
+- numpy >=1.12.1
+- pandas >=0.22.0
+- bokeh >=0.12.3
+- pytest

--- a/environment.yml
+++ b/environment.yml
@@ -5,3 +5,7 @@ dependencies:
 - pandas >=0.22.0
 - bokeh >=0.12.3
 - pytest
+pip:
+- ipython
+- ipykernel
+- cylp==0.7.1

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 name: taxdata-dev
 dependencies:
 - python>=2.7.14
-- numpy=1.13.3
+- numpy=1.12.1
 - pandas=0.20.3
 - scipy=0.18.1
 - bokeh >=0.12.3


### PR DESCRIPTION
This PR proposes a simple `environment.yml` file that can easily be used and built on in the future. The file proposed here probably does not have all of the packages required to run everything in taxdata. However, I think we can get there by using this file, adding packages, and updating package versions as needed. 

I'm having trouble installing cylp, but the rest of the packages install OK. It may be worth adding separate documentation for installing cylp since it requires several extra steps. @andersonfrailey I understand that you are trying to find an alternative to cylp. So, I trust your judgement in adding this documentation or waiting until a more permanent linear programming solution is found.