### PR TITLE
fix elderly dependents variable

### DIFF
--- a/cps_data/finalprep.py
+++ b/cps_data/finalprep.py
@@ -64,10 +64,10 @@ def main():
         'NU13': 'nu13',
         'NU05': 'nu05',
         'N24': 'n24',
-        'ELDERLY_DEPENDENT': 'elderly_dependent',
         'F2441': 'f2441'
     }
     data = data.rename(columns=renames)
+    data['elderly_dependent'] = np.where(data['ELDERLY_DEPENDENT'] > 0, 1, 0)
     data['MARS'] = np.where(data.JS == 3, 4, data.JS)
 
     # Use taxpayer and spouse records to get total tax unit earnings and AGI

--- a/puf_data/StatMatch/Matching/cps_rets.py
+++ b/puf_data/StatMatch/Matching/cps_rets.py
@@ -713,7 +713,7 @@ class Returns(object):
                     if individual['a_age'] >= 21:
                         record['n21'] += 1
                     if individual['a_age'] >= 65:
-                        record['elderly_dependent'] += 1
+                        record['elderly_dependent'] = 1
 
         cahe = np.nan
 
@@ -852,8 +852,8 @@ class Returns(object):
         self.house_units[iy]['nu18'] += self.house_units[ix]['nu18']
         self.house_units[iy]['n1820'] += self.house_units[ix]['n1820']
         self.house_units[iy]['n21'] += self.house_units[ix]['n21']
-        elderly = self.house_units[ix]['elderly_dependent']
-        self.house_units[iy]['elderly_dependent'] += elderly
+        if self.house_units[ix]['elderly_dependent'] == 1:
+            self.house_units[iy]['elderly_dependent'] = 1
 
     def tax_units_search(self):
         """


### PR DESCRIPTION
This PR changes the logic used to create the `elderly_dependent` variable so that it will be either a 0 (no elderly dependents) or 1 (elderly dependent(s)), as the record metadata indicates.