### PR TITLE
Add weights tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,52 +10,39 @@ def test_path():
 
 
 @pytest.fixture(scope='session')
-def cps_path(test_path):
-    return os.path.join(test_path, '../cps_data/cps.csv.gz')
+def cps(test_path):
+    return pd.read_csv(os.path.join(test_path, '../cps_data/cps.csv.gz'))
 
 
 @pytest.fixture(scope='session')
-def cps(cps_path):
-    return pd.read_csv(cps_path)
-
-
-@pytest.fixture(scope='session')
-def puf_path(test_path):
-    return os.path.join(test_path, '../puf_data/puf.csv')
-
-
-@pytest.fixture(scope='session')
-def puf(puf_path):
-    return pd.read_csv(puf_path)
+def puf(test_path):
+    return pd.read_csv(os.path.join(test_path, '../puf_data/puf.csv'))
 
 
 @pytest.fixture(scope='session')
 def metadata(test_path):
-    path = os.path.join(test_path, 'records_metadata.json')
-    with open(path, 'r') as f:
-        return json.load(f)
+    with open(os.path.join(test_path, 'records_metadata.json'), 'r') as mdf:
+        return json.load(mdf)
 
 
 @pytest.fixture(scope='session')
-def benefit_growth_rates_path(test_path):
-    return os.path.join(test_path, '../cps_stage3/growth_rates.csv')
+def cps_weights_path(test_path):
+    return 
 
 
 @pytest.fixture(scope='session')
-def raw_cps_path(test_path):
-    return os.path.join(test_path, '../cps_data/cps_raw_rename.csv.gz')
+def cps_weights(test_path):
+    return pd.read_csv(os.path.join(test_path,
+                                    '../cps_stage2/cps_weights.csv.gz'))
 
 
 @pytest.fixture(scope='session')
-def raw_weights_path(test_path):
-    return os.path.join(test_path, '../cps_stage2/cps_weights_raw.csv.gz')
+def puf_weights(test_path):
+    return pd.read_csv(os.path.join(test_path,
+                                    '../puf_stage2/puf_weights.csv.gz'))
 
 
 @pytest.fixture(scope='session')
-def growfactors_path(test_path):
-    return os.path.join(test_path, '../stage1/growfactors.csv')
-
-
-@pytest.fixture(scope='session')
-def growfactors(growfactors_path):
-    return pd.read_csv(growfactors_path)
+def growfactors(test_path):
+    return pd.read_csv(os.path.join(test_path, '../stage1/growfactors.csv'),
+                       index_col='YEAR')

--- a/tests/test_extrapolation.py
+++ b/tests/test_extrapolation.py
@@ -3,20 +3,24 @@ Run the tests from the cps_stage3 directory using the following command:
 py.test test_extrapolation.py
 """
 
-import pandas as pd
-import numpy as np
-import sys
 import os
+import sys
 import pytest
+import numpy as np
+import pandas as pd
+
 file_path = os.path.abspath(os.path.dirname(__file__))
-sys.path.append(os.path.join(file_path, '../cps_stage3'))
+cps_stage3_path = os.path.join(file_path, '../cps_stage3')
+sys.path.append(cps_stage3_path)
+ben_g_r_path = os.path.join(file_path, '../cps_stage3/growth_rates.csv')
+raw_cps_path = os.path.join(file_path, '../cps_data/cps_raw_rename.csv.gz')
+raw_wgt_path = os.path.join(file_path, '../cps_stage2/cps_weights_raw.csv.gz')
 
 from extrapolation import Benefits
 
 
 @pytest.mark.skip
-def test_add_participants(benefit_growth_rates_path, raw_cps_path,
-                          raw_weights_path):
+def test_add_participants(ben_g_r_path, raw_cps_path, raw_wgt_path):
     """
     Checks
         1. those with benefits still have benefits
@@ -24,9 +28,9 @@ def test_add_participants(benefit_growth_rates_path, raw_cps_path,
     """
     # use medicare since that program needs participants added in 2015
     benefit_names = ["mcare"]
-    ben = Benefits(growth_rates=benefit_growth_rates_path,
+    ben = Benefits(growth_rates=ben_g_r_path,
                    cps_benefit=raw_cps_path,
-                   cps_weights=raw_weights_path,
+                   cps_weights=raw_wgt_path,
                    benefit_names=benefit_names)
 
     # prepare test data
@@ -125,8 +129,7 @@ def test_add_participants(benefit_growth_rates_path, raw_cps_path,
 
 
 @pytest.mark.skip
-def test_remove_participants(benefit_growth_rates_path, raw_cps_path,
-                             raw_weights_path):
+def test_remove_participants(ben_g_r_path, raw_cps_path, raw_wgt_path):
     """
     Checks
         1. those without benefits still do not have benefits
@@ -134,9 +137,9 @@ def test_remove_participants(benefit_growth_rates_path, raw_cps_path,
     """
     # use snap since that program needs participants removed in 2015
     benefit_names = ["snap"]
-    ben = Benefits(growth_rates=benefit_growth_rates_path,
+    ben = Benefits(growth_rates=ben_g_r_path,
                    cps_benefit=raw_cps_path,
-                   cps_weights=raw_weights_path,
+                   cps_weights=raw_wgt_path,
                    benefit_names=benefit_names)
 
     # prepare test data

--- a/tests/test_growfactors.py
+++ b/tests/test_growfactors.py
@@ -1,36 +1,14 @@
 import numpy as np
 
 
-def min_max(data, meta, dataname):
-    """
-    Test for ensuring all variables are within their logical minimum and
-    maximum
-    """
-    for var in meta.keys():
-        availability = meta[var]['availability']
-        min_value = meta[var]['range']['min']
-        max_value = meta[var]['range']['max']
-        in_data = True
-        if dataname not in availability:
-            in_data = False
-        if in_data:
-            m = '{}-{} contains values less than min value'.format(dataname,
-                                                                   var)
-            assert np.all(data[var] >= min_value), m
-            m = '{}-{} contains values greater than max value'.format(dataname,
-                                                                      var)
-            assert np.all(data[var] <= max_value), m
-
-
 def test_growfactor_start_year(growfactors):
-    first_year = growfactors['YEAR'].min()
+    first_growfactors_year = growfactors.index.min()
     first_taxcalc_policy_year = 2013
-    assert first_year <= first_taxcalc_policy_year
+    assert first_growfactors_year <= first_taxcalc_policy_year
 
 
 def test_growfactor_values(growfactors):
-    first_year = growfactors['YEAR'].min()
-    growfactors.set_index('YEAR', inplace=True)
+    first_year = growfactors.index.min()
     for fname in growfactors:
         if fname != 'YEAR':
             assert growfactors[fname][first_year] == 1.0

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -1,0 +1,36 @@
+import pytest
+import numpy as np
+
+
+@pytest.mark.parametrize('kind', ['puf', 'cps'])
+def test_weights(kind, puf_weights, cps_weights, growfactors):
+    # test range of years in weights file
+    first_growfactors_year = growfactors.index.min()
+    last_growfactors_year = growfactors.index.max()
+    if kind == 'puf':
+        weights = puf_weights
+        first_weights_year = 2011  # change value when using newer PUF data
+        last_weights_year = last_growfactors_year
+    elif kind == 'cps':
+        weights = cps_weights
+        first_weights_year = 2014  # change value when using newer CPS data
+        last_weights_year = last_growfactors_year
+    else:
+       raise ValueError('illegal weights kind = {}'.format(kind))
+    sorted_weights_columns = sorted([col for col in weights])
+    first_weights_column = sorted_weights_columns[0]
+    last_weights_column = sorted_weights_columns[-1]
+    assert first_weights_column == 'WT{}'.format(first_weights_year)
+    assert last_weights_column == 'WT{}'.format(last_weights_year)
+    # test range of weight values for each year
+    min_weight = 0  # must be non-negative,
+    max_weight = 1800000  # but can be large
+    for col in weights:
+       if weights[col].min() < min_weight:
+           msg = '{} weights[{}].min()={} < {}'
+           raise ValueError(msg.format(kind, col,
+                                       weights[col].min(), min_weight))
+       if weights[col].max() > max_weight:
+           msg = '{} weights[{}].max()={} > {}'
+           raise ValueError(msg.format(kind, col,
+                                       weights[col].max(), max_weight))

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -3,7 +3,7 @@ import numpy as np
 
 
 @pytest.mark.parametrize('kind', ['puf', 'cps'])
-def test_weights(kind, puf_weights, cps_weights, growfactors):
+def test_weights(kind, puf_weights, cps_weights, growfactors, puf, cps):
     # test range of years in weights file
     first_growfactors_year = growfactors.index.min()
     last_growfactors_year = growfactors.index.max()
@@ -11,20 +11,24 @@ def test_weights(kind, puf_weights, cps_weights, growfactors):
         weights = puf_weights
         first_weights_year = 2011  # change value when using newer PUF data
         last_weights_year = last_growfactors_year
+        data = puf
     elif kind == 'cps':
         weights = cps_weights
         first_weights_year = 2014  # change value when using newer CPS data
         last_weights_year = last_growfactors_year
+        data = cps
     else:
-       raise ValueError('illegal weights kind = {}'.format(kind))
+       raise ValueError('illegal kind = {}'.format(kind))
     sorted_weights_columns = sorted([col for col in weights])
     first_weights_column = sorted_weights_columns[0]
     last_weights_column = sorted_weights_columns[-1]
     assert first_weights_column == 'WT{}'.format(first_weights_year)
     assert last_weights_column == 'WT{}'.format(last_weights_year)
+    # test number of rows in weights file
+    assert weights.shape[0] == data.shape[0]
     # test range of weight values for each year
-    min_weight = 0  # must be non-negative,
-    max_weight = 1800000  # but can be large
+    min_weight = 0  # weight must be non-negative,
+    max_weight = 1800000  # but can be quite large
     for col in weights:
        if weights[col].min() < min_weight:
            msg = '{} weights[{}].min()={} < {}'

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -3,20 +3,20 @@ import numpy as np
 
 
 @pytest.mark.parametrize('kind', ['puf', 'cps'])
-def test_weights(kind, puf_weights, cps_weights, growfactors, puf, cps):
+def test_weights(kind, puf_weights, cps_weights, growfactors):
     # test range of years in weights file
     first_growfactors_year = growfactors.index.min()
     last_growfactors_year = growfactors.index.max()
     if kind == 'puf':
         weights = puf_weights
         first_weights_year = 2011  # change value when using newer PUF data
+        expected_num_records = 239002  # change value when using newer PUF data
         last_weights_year = last_growfactors_year
-        data = puf
     elif kind == 'cps':
         weights = cps_weights
         first_weights_year = 2014  # change value when using newer CPS data
+        expected_num_records = 456465  # change value when using newer CPS data
         last_weights_year = last_growfactors_year
-        data = cps
     else:
        raise ValueError('illegal kind = {}'.format(kind))
     sorted_weights_columns = sorted([col for col in weights])
@@ -25,7 +25,7 @@ def test_weights(kind, puf_weights, cps_weights, growfactors, puf, cps):
     assert first_weights_column == 'WT{}'.format(first_weights_year)
     assert last_weights_column == 'WT{}'.format(last_weights_year)
     # test number of rows in weights file
-    assert weights.shape[0] == data.shape[0]
+    assert weights.shape[0] == expected_num_records
     # test range of weight values for each year
     min_weight = 0  # weight must be non-negative,
     max_weight = 1800000  # but can be quite large


### PR DESCRIPTION
Add tests of values in the two `*_weights.csv.gz` files.

@andersonfrailey, the PUF weights test fails when `min_weight = 1` (rather than zero).
Why are there PUF records with zero weight?
