### PR TITLE
Update environment.yml list of core requirements

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,3 @@ dependencies:
 - scipy=0.18.1
 - bokeh >=0.12.3
 - pytest
-- pip:
-  - ipython
-  - ipykernel


### PR DESCRIPTION
This pull request removes two notebook-related tools from the taxdata `environment.yml` file now that there are no notebooks in the repository.  Using notebooks in personal work is still an option, but notebooks are not part of the core work being done in the taxdata repository.  Removing these notebook-related tools from the taxdata `environment.yml` file noticeably speeds up the running of the tests by Travis-CI on GitHub.