### PR TITLE
Make s006 an integer in the CPS

### DIFF
--- a/cps_data/finalprep.py
+++ b/cps_data/finalprep.py
@@ -133,7 +133,7 @@ def main():
     data['e00200'] = data['e00200p'] + data['e00200s']
     data['e00900'] = data['e00900p'] + data['e00900s']
     data['e02100'] = data['e02100p'] + data['e02100s']
-    data['s006'] *= 100.
+    data['s006'] *= 100
     print('Exporting...')
     data.to_csv('cps.csv', index=False)
     subprocess.check_call(["gzip", "-nf", "cps.csv"])


### PR DESCRIPTION
Back in PR #175 we made all of the variables in the CPS integers but in #187 we moved the multiplication of s006 to `cps_data/final_prep.py`, which caused `s006` to be a `float` type. This PR makes `s006` an integer to be consistent with #175.