### PR TITLE
Make test of XTOT vs sum of UBI n* vars stronger

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,6 @@
 name: taxdata-dev
+channels:
+- conda-forge
 dependencies:
 - python>=2.7.14
 - numpy=1.12.1


### PR DESCRIPTION
This pull request strengthens a relationship test in the `tests/test_data.py` file to make it equivalent to the two tests removed from Tax-Calculator in [taxcalc pull request 2013](https://github.com/open-source-economics/Tax-Calculator/pull/2013).