### PR TITLE
Add incomplete Makefile that documents and automates common development operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+# GNU Makefile that documents and automates common development operations
+#              using the GNU make tool (version >= 3.81)
+# USAGE: taxdata$ make [TARGET]
+
+FILES_TO_MAKE = growfactors.csv
+
+.PHONY=help
+help:
+	@echo "USAGE: make [TARGET]"
+	@echo "TARGETS:"
+	@echo "help       : show help message"
+	@echo "clean      : remove all made files (see 'all' file list)"
+	@echo "all        : make each of the following files:"
+	@echo "               growfactors.csv"
+	@echo "pytest     : generate report for and cleanup after pytest"
+	@echo "cstest     : generate coding-style errors with pycodestyle"
+	@echo "git-sync   : synchronize local, origin, and upstream Git repos"
+	@echo "git-pr N=n : create local pr-n branch containing upstream PR"
+
+
+.PHONY=clean
+clean:
+	@find . -name *pyc -exec rm {} \;
+	@rm -f $(FILES_TO_MAKE)
+
+define pytest-cleanup
+find . -name *cache -maxdepth 1 -exec rm -r {} \;
+endef
+
+.PHONY=pytest
+pytest:
+	@pytest -n4
+	@$(pytest-cleanup)
+
+.PHONY=cstest
+cstest:
+	pycodestyle .
+
+.PHONY=git-sync
+git-sync:
+	@./gitsync
+
+.PHONY=git-pr
+git-pr:
+	@./gitpr $(N)


### PR DESCRIPTION
This pull request adds a taxdata/Makefile that documents many common development operations, some of which are not documented elsewhere in the repository. Using the GNU make tool to invoke operations in the Makefile makes it easier to conduct common development operations such as cleaning up files, building the CSV files in the correct order and in an efficient manner, conducting the pytest suite, and conducting coding-style tests.

More details on each of these operations can be obtained by entering, at the command line in the top directory of the repository, the command `make help` or simply `make`. Here is what happens:
```
taxdata$ make
USAGE: make [TARGET]
TARGETS:
help       : show help message
clean      : remove all made files (see 'all' file list)
all        : make each of the following files:
               growfactors.csv
pytest     : generate report for and cleanup after pytest
cstest     : generate coding-style errors with pycodestyle
git-sync   : synchronize local, origin, and upstream Git repos
git-pr N=n : create local pr-n branch containing upstream PR
```
The GNU make command-line tool comes with Linux and Mac Xcode and can be downloaded and installed easily on Windows. The Tax-Calculator/Makefile expects make version 3.81 or higher. On a Mac after installing Xcode command-line utilities, we have this:
```
taxdata$ make --version
GNU Make 3.81
Copyright (C) 2006  Free Software Foundation, Inc.
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
PARTICULAR PURPOSE.

This program built for i386-apple-darwin11.3.0
```