### PR TITLE
Update taxdata/README.md info and csvcopy.sh script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,10 +76,6 @@ puf-files: puf_stage1/growfactors.csv \
            puf_stage2/puf_weights.csv.gz \
            puf_stage3/puf_ratios.csv
 
-puf_data/puf.csv: puf_data/finalprep.py \
-                  puf_data/cps-matched-puf.csv
-	cd puf_data ; python finalprep.py
-
 puf_stage1/Stage_I_factors.csv: puf_stage1/stage1.py \
                                 puf_stage1/CBO_baseline.csv \
                                 puf_stage1/IRS_return_projection.csv \
@@ -94,6 +90,10 @@ puf_stage1/Stage_I_factors.csv: puf_stage1/stage1.py \
 puf_stage1/growfactors.csv: puf_stage1/factors_finalprep.py \
                             puf_stage1/Stage_I_factors.csv
 	cd puf_stage1 ; python factors_finalprep.py
+
+puf_data/puf.csv: puf_data/finalprep.py \
+                  puf_data/cps-matched-puf.csv
+	cd puf_data ; python finalprep.py
 
 puf_stage2/puf_weights.csv.gz: puf_stage2/stage2.py \
                                puf_stage2/solve_lp_for_year.py \
@@ -115,17 +115,17 @@ cps-files: cps_stage1/stage_2_targets.csv \
            cps_stage2/cps_weights.csv.gz \
            cps_stage4/cps_benefits.csv.gz
 
-cps_data/cps.csv.gz: cps_data/finalprep.py \
-                     cps_data/cps_raw.csv.gz \
-                     cps_data/adjustment_targets.csv \
-                     cps_data/benefitprograms.csv
-	cd cps_data ; python finalprep.py
-
 cps_stage1/stage_2_targets.csv: cps_stage1/stage1.py \
                                 cps_stage1/SOI_estimates.csv \
                                 puf_stage1/Stage_I_factors.csv \
                                 puf_stage1/Stage_II_targets.csv
 	cd cps_stage1 ; python stage1.py
+
+cps_data/cps.csv.gz: cps_data/finalprep.py \
+                     cps_data/cps_raw.csv.gz \
+                     cps_data/adjustment_targets.csv \
+                     cps_data/benefitprograms.csv
+	cd cps_data ; python finalprep.py
 
 cps_stage2/cps_weights.csv.gz: cps_stage2/stage2.py \
                                cps_data/cps_raw.csv.gz \

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,6 @@ help:
 	@echo "                puf_ratios.csv"
 	@echo "cps-files   : make each of the following files:"
 	@echo "                cps.csv.gz"
-	@echo "                growfactors.csv"
 	@echo "                cps_weights.csv.gz"
 	@echo "                cps_benefits.csv.gz"
 	@echo "all         : make both puf-files and cps-files"
@@ -71,10 +70,14 @@ git-pr:
 	@./gitpr $(N)
 
 .PHONY=puf-files
-puf-files: puf_stage1/growfactors.csv \
-           puf_data/puf.csv \
+puf-files: puf_data/puf.csv \
+           puf_stage1/growfactors.csv \
            puf_stage2/puf_weights.csv.gz \
            puf_stage3/puf_ratios.csv
+
+puf_data/puf.csv: puf_data/finalprep.py \
+                  puf_data/cps-matched-puf.csv
+	cd puf_data ; python finalprep.py
 
 puf_stage1/Stage_I_factors.csv: puf_stage1/stage1.py \
                                 puf_stage1/CBO_baseline.csv \
@@ -91,10 +94,6 @@ puf_stage1/growfactors.csv: puf_stage1/factors_finalprep.py \
                             puf_stage1/Stage_I_factors.csv
 	cd puf_stage1 ; python factors_finalprep.py
 
-puf_data/puf.csv: puf_data/finalprep.py \
-                  puf_data/cps-matched-puf.csv
-	cd puf_data ; python finalprep.py
-
 puf_stage2/puf_weights.csv.gz: puf_stage2/stage2.py \
                                puf_stage2/solve_lp_for_year.py \
                                puf_data/cps-matched-puf.csv \
@@ -110,22 +109,22 @@ puf_stage3/puf_ratios.csv: puf_stage3/stage3.py \
 	cd puf_stage3 ; python stage3.py
 
 .PHONY=cps-files
-cps-files: cps_stage1/stage_2_targets.csv \
-           cps_data/cps.csv.gz \
+cps-files: cps_data/cps.csv.gz \
+           cps_stage1/stage_2_targets.csv \
            cps_stage2/cps_weights.csv.gz \
            cps_stage4/cps_benefits.csv.gz
-
-cps_stage1/stage_2_targets.csv: cps_stage1/stage1.py \
-                                cps_stage1/SOI_estimates.csv \
-                                puf_stage1/Stage_I_factors.csv \
-                                puf_stage1/Stage_II_targets.csv
-	cd cps_stage1 ; python stage1.py
 
 cps_data/cps.csv.gz: cps_data/finalprep.py \
                      cps_data/cps_raw.csv.gz \
                      cps_data/adjustment_targets.csv \
                      cps_data/benefitprograms.csv
 	cd cps_data ; python finalprep.py
+
+cps_stage1/stage_2_targets.csv: cps_stage1/stage1.py \
+                                cps_stage1/SOI_estimates.csv \
+                                puf_stage1/Stage_I_factors.csv \
+                                puf_stage1/Stage_II_targets.csv
+	cd cps_stage1 ; python stage1.py
 
 cps_stage2/cps_weights.csv.gz: cps_stage2/stage2.py \
                                cps_data/cps_raw.csv.gz \

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,8 @@ git-pr:
 	@./gitpr $(N)
 
 .PHONY=puf-files
-puf-files: puf_data/puf.csv \
-           puf_stage1/growfactors.csv \
+puf-files: puf_stage1/growfactors.csv \
+           puf_data/puf.csv \
            puf_stage2/puf_weights.csv.gz \
            puf_stage3/puf_ratios.csv
 
@@ -110,8 +110,8 @@ puf_stage3/puf_ratios.csv: puf_stage3/stage3.py \
 	cd puf_stage3 ; python stage3.py
 
 .PHONY=cps-files
-cps-files: cps_data/cps.csv.gz \
-           cps_stage1/stage_2_targets.csv \
+cps-files: cps_stage1/stage_2_targets.csv \
+           cps_data/cps.csv.gz \
            cps_stage2/cps_weights.csv.gz \
            cps_stage4/cps_benefits.csv.gz
 

--- a/README.md
+++ b/README.md
@@ -44,22 +44,28 @@ The best documentation of the data-preparation workflow is the
 the Python script that generates each made file.  The files made in
 early stages of the workflow serve as input files in later stages,
 which means there is a cascading effect of changes in the scripts
-and/or input files.  The Makefile handles all this complexity in an
-economical way because it executes scripts to make new versions of
+and/or input files.  The Makefile automates this complex workflow in
+an economical way because it executes scripts to make new versions of
 made files only when necessary.  Start exploring the Makefile by
-running the `make help` command.
+running the `make help` command.  If you want more background on the
+make utility and makefiles, search for Internet links with the
+keywords `makefile` and `automate`.
 
 Note that the stage2 linear program that generates the weights file is
 very long-running, taking five or more hours depending on your
 computer's CPU speed.  We are considering options for speeding up this
 stage2 work, but for the time being you can execute `make puf-files`
 and `make cps-files` in separate terminal windows to have the two
-stage2 linear programs run in parallel.  If you are generating the
+stage2 linear programs run in parallel.  (If you try this parallel
+execution approach, be sure to wait for the `make puf-files` job to
+begin stage2 work before executing the `make cps-files` command in
+the other terminal window.  This is necessary because the CPS stage1
+work depends on output from PUF stage1.)  If you are generating the
 taxdata made files in an overnight run, then simply execute the `make
 all` command.
 
 You can copy the made files to your local Tax-Calculator directory
-tree using the [`csvcopy.sh` bash script](csvcopy.sh).  Use the dryrun
+tree using the [`csvcopy.sh`](csvcopy.sh) bash script.  Use the `dryrun`
 option to see which files would be copied (because they are newer than
 the corresponding files in the Tax-Calculator directory tree) without
 actually doing the file copies.  At the terminal command-prompt in the

--- a/README.md
+++ b/README.md
@@ -17,16 +17,16 @@ taxdata repository or the Tax-Calculator repository.
 
 Each of these two sets of data files contains several types of files:
 
-1. a sample data file containing variables for each tax filing unit;
+0. a sample data file containing variables for each tax filing unit;
 
-2. a factors file containing annual variable extrapolation factors;
+1. a factors file containing annual variable extrapolation factors;
 
-3. a weights file containing annual weights for each filing unit;
+2. a weights file containing annual weights for each filing unit;
 
-4. a ratios file containing annual adjustment ratios for some variables
+3. a ratios file containing annual adjustment ratios for some variables
    (currently only the PUF data set includes a ratios file);
 
-5. a benefits file containing extrapolated benefits for each filing unit
+4. a benefits file containing extrapolated benefits for each filing unit
    (currently only the CPS data set includes a benefits file).
 
 Note that the factors file is the same in both sets of data files
@@ -52,7 +52,7 @@ running the `make help` command.
 Note that the stage2 linear program that generates the weights file is
 very long-running, taking five or more hours depending on your
 computer's CPU speed.  We are considering options for speeding up this
-stage2 work, but for the time being your can execute `make puf-files`
+stage2 work, but for the time being you can execute `make puf-files`
 and `make cps-files` in separate terminal windows to have the two
 stage2 linear programs run in parallel.  If you try this, be sure to
 wait a bit until the `make puf-files` starts on stage2 before running
@@ -64,8 +64,8 @@ You can copy the made files to your local Tax-Calculator directory
 tree using the [`csvcopy.sh` bash script](csvcopy.sh).  Use the dryrun
 option to see which files would be copied (because they are newer than
 the corresponding files in the Tax-Calculator directory tree) without
-doing the actual copy.  At the terminal command-prompt in the top-level
-taxdata directory, execute `./csvcopy` to get help.
+actually doing the file copies.  At the terminal command-prompt in the
+top-level taxdata directory, execute `./csvcopy.sh` to get help.
 
 
 Contributing to taxdata Repository

--- a/README.md
+++ b/README.md
@@ -56,9 +56,12 @@ stage2 work, but for the time being you can execute `make puf-files`
 and `make cps-files` in separate terminal windows to have the two
 stage2 linear programs run in parallel.  If you try this, be sure to
 wait a bit until the `make puf-files` starts on stage2 before running
-the `make cps-files` command in the other terminal window.  If you are
-generating the taxdata made files in an overnight run, then simply
-execute the `make all` command.
+the `make cps-files` command in the other terminal window. (This delay
+before executing `make cps-files` allows the `make puf-files` command
+to execute --- without any interference --- the stage1 logic, which is
+part of making both sets of files.) If you are generating the taxdata
+made files in an overnight run, then simply execute the `make all`
+command.
 
 You can copy the made files to your local Tax-Calculator directory
 tree using the [`csvcopy.sh` bash script](csvcopy.sh).  Use the dryrun

--- a/README.md
+++ b/README.md
@@ -1,28 +1,21 @@
 About taxdata Repository
 ========================
 
-### IMPORTANT
-
-To run `puf_stage2/stage2.py`, you must first install the CyLP package.
-Installation instructions can be found [here](https://github.com/coin-or/CyLP#installation)
-
----
-
 This repository prepares data used in the [Tax-Calculator
 repository](https://github.com/open-source-economics/Tax-Calculator).
 
-The data produced here, all of which have CSV format, provide
+The data files produced here, all of which have CSV format, provide
 two different sets of data files for Tax-Calculator:
 
-* A set based on a recent **IRS-SOI Public Use File (PUF)**
+- A set based on a recent **IRS-SOI Public Use File (PUF)**
 
-* A set based on recent **Census Current Population Survey (CPS)** data
+- A set based on recent **Census Current Population Survey (CPS)** data
 
 Because the PUF data are restricted in their use, the IRS-SOI-supplied
 PUF file and the `puf.csv` data file produced here are not part of the
-taxdata or the Tax-Calculator repository.
+taxdata repository or the Tax-Calculator repository.
 
-Each of these two sets of data files contains four files:
+Each of these two sets of data files contains several types of files:
 
 1. a sample data file containing variables for each tax filing unit;
 
@@ -30,59 +23,64 @@ Each of these two sets of data files contains four files:
 
 3. a weights file containing annual weights for each filing unit;
 
-4. a ratios file containing annual adjustment ratios for some variables.
+4. a ratios file containing annual adjustment ratios for some variables
+   (currently only the PUF data set includes a ratios file);
+
+5. a benefits file containing extrapolated benefits for each filing unit
+   (currently only the CPS data set includes a benefits file).
 
 Note that the factors file is the same in both sets of data files
 because the variable extrapolation factors are independent of the
-sample data being used.  But the weights and ratios files do depend on
-the data file, so they are different in the two sets of data files.
+sample data being used.  But the weights, ratios, and benefits files
+do depend on the data file, so they are different in the two sets of
+data files.
 
 
-Data-Preparation Documentation
-------------------------------
+Data-Preparation Documentation and Workflow
+-------------------------------------------
 
-**IRS-SOI Public Use File (PUF)** documentation:
+The best documentation of the data-preparation workflow is the
+[taxdata Makefile](Makefile).  The Makefile shows the input files and
+the Python script that generates each made file.  The files made in
+early stages of the workflow serve as input files in later stages,
+which means there is a cascading effect of changes in the scripts
+and/or input files.  The Makefile handles all this complexity in an
+economical way because it executes scripts to make new versions of
+made files only when necessary.  Start exploring the Makefile by
+running the `make help` command.
 
-1. [PUF-based sample data](puf_data/README.md);
+Note that the stage2 linear program that generates the weights file is
+very long-running, taking five or more hours depending on your
+computer's CPU speed.  We are considering options for speeding up this
+stage2 work, but for the time being your can execute `make puf-files`
+and `make cps-files` in separate terminal windows to have the two
+stage2 linear programs run in parallel.  If you try this, be sure to
+wait a bit until the `make puf-files` starts on stage2 before running
+the `make cps-files` command in the other terminal window.  If you are
+generating the taxdata made files in an overnight run, then simply
+execute the `make all` command.
 
-2. [grow factors](stage1/README.md)
-
-3. [PUF-based sample weights](puf_stage2/README.md);
-
-4. [PUF-based adjustment ratios](puf_stage3/README.md).
-
-**Census Current Population Survey (CPS)** documentation is available here:
-
-1. [CPS-based sample data](cps_data/README.md);
-
-2. [grow factors](stage1/README.md)
-
-3. [CPS-based sample weights](cps_stage2/README.md);
-
-4. [CPS-based adjustment ratios](cps_stage3/README.md).
-
-
-Contributing
-------------
-Before opening up a pull request, run `pytest` to ensure all tests pass.
+You can copy the made files to your local Tax-Calculator directory
+tree using the [`csvcopy.sh` bash script](csvcopy.sh).  Use the dryrun
+option to see which files would be copied (because they are newer than
+the corresponding files in the Tax-Calculator directory tree) without
+doing the actual copy.  At the terminal command-prompt in the top-level
+taxdata directory, execute `./csvcopy` to get help.
 
 
-Work-Flow Documentation
------------------------
+Contributing to taxdata Repository
+----------------------------------
 
-The sequence of operations required to make the two sets of data files
-is contained in the [`csvmake` bash script](csvmake), which also
-automates the preparation work-flow (except on Windows).
-
-The sequence of operations required to install the two sets of data
-files in the Tax-Calculator repository is contained in the [`csvcopy`
-bash script](csvcopy), which also automates the installation work-flow
-(except on Windows).
+Before creating a GitHub pull request, on your development branch in
+the top-level directory of the taxdata repository, run `make cstest`
+to make sure your proposed code is consistent with the repository's
+coding style and then run `make pytest` to ensure that all the tests
+pass.
 
 
 Contributors
 ------------
+- Anderson Frailey
 - John O'Hare
 - Amy Xu
-- Anderson Frailey
 - Martin Holmer

--- a/README.md
+++ b/README.md
@@ -54,14 +54,9 @@ very long-running, taking five or more hours depending on your
 computer's CPU speed.  We are considering options for speeding up this
 stage2 work, but for the time being you can execute `make puf-files`
 and `make cps-files` in separate terminal windows to have the two
-stage2 linear programs run in parallel.  If you try this, be sure to
-wait a bit until the `make puf-files` starts on stage2 before running
-the `make cps-files` command in the other terminal window. (This delay
-before executing `make cps-files` allows the `make puf-files` command
-to execute --- without any interference --- the stage1 logic, which is
-part of making both sets of files.) If you are generating the taxdata
-made files in an overnight run, then simply execute the `make all`
-command.
+stage2 linear programs run in parallel.  If you are generating the
+taxdata made files in an overnight run, then simply execute the `make
+all` command.
 
 You can copy the made files to your local Tax-Calculator directory
 tree using the [`csvcopy.sh` bash script](csvcopy.sh).  Use the dryrun

--- a/csvcopy.sh
+++ b/csvcopy.sh
@@ -74,8 +74,8 @@ else
 fi
 copyifdiff $SRCFILENAME $TAXDATADIR$SRCFILENAME $TAXCALCDIR$DSTFILENAME $DRYRUN
 
-# copy stage1/growfactors.csv file if different
-TAXDATADIR="stage1/"
+# copy puf_stage1/growfactors.csv file if different
+TAXDATADIR="puf_stage1/"
 FILENAME="growfactors.csv"
 copyifdiff $FILENAME $TAXDATADIR$FILENAME $TAXCALCDIR$FILENAME $DRYRUN
 


### PR DESCRIPTION
This pull request updates the main `README.md` file to reflect the use of the `taxdata/Makefile` as the way to do data-preparation in the taxdata repository.

It also updates the `csvcopy.sh` script to reflect the fact that the `growfactors.csv` file has recently been moved from the `stage1` directory to the `puf_stage1` directory.

@andersonfrailey and @hdoupe, can you suggest improvements in the new documentation?  Do you have questions that the new documentation does not answer?

With respect to the old plan of having a `README.md` file in each subdirectory, it seems as if that approach to documentation has been far from ideal.  What about just removing all of that documentation because that information is in the `Makefile`?