### PR TITLE
Revise cps_stage4/extrapolation.py script

### DIFF
--- a/cps_stage4/extrapolation.py
+++ b/cps_stage4/extrapolation.py
@@ -24,7 +24,7 @@ class Benefits():
         self.benefit_names = benefit_names
 
 
-    def increment_year(self, tol=0.01):
+    def increment_year(self, tol):
         self.current_year += 1
         print("starting year", self.current_year)
         WT = self.WT.loc[:, 'WT'+str(self.current_year)]
@@ -79,7 +79,7 @@ class Benefits():
 
     @staticmethod
     def _extrapolate(WT, I, benefits, prob, target,
-                     benefit_name, benefit_year, tol=0.01, J=15):
+                     benefit_name, benefit_year, tol, J=15):
         """
         Goal: get number of participants as close to target as possible
         Steps:
@@ -283,7 +283,7 @@ if __name__ == "__main__":
     ben = Benefits()
 
     for _ in range(13):
-        ben.increment_year()
+        ben.increment_year(tol=0.05)
 
     # drop unnecessary variables
     drop_list = []

--- a/cps_stage4/extrapolation.py
+++ b/cps_stage4/extrapolation.py
@@ -270,7 +270,7 @@ class Benefits(object):
 if __name__ == '__main__':
     # create extrapolated benefits
     ben = Benefits()
-    for _ in range(SYEAR + 1, LYEAR + 1):
+    for _ in range(SYEAR, LYEAR):
         ben.increment_year(tol=0.05)
     # drop unnecessary variables
     drop_list = []

--- a/cps_stage4/extrapolation.py
+++ b/cps_stage4/extrapolation.py
@@ -199,6 +199,7 @@ class Benefits(object):
         self.index = cps_benefit['SEQUENCE']
 
         cps_weights = pd.read_csv('../cps_stage2/cps_weights.csv.gz')
+        cps_weights = cps_weights.astype(np.float64).mul(0.01)
         cps_weights['SEQUENCE'] = self.index
         cps_weights.set_index('SEQUENCE', inplace=True)
 

--- a/cps_stage4/extrapolation.py
+++ b/cps_stage4/extrapolation.py
@@ -156,7 +156,7 @@ class Benefits(object):
                            'benefits'] = avg_benefit
 
         result = pd.concat([noncandidates, candidates], axis=0,
-                           ignore_index=False)
+                           sort=False, ignore_index=False)
         del candidates
         del noncandidates
 

--- a/cps_stage4/extrapolation.py
+++ b/cps_stage4/extrapolation.py
@@ -283,8 +283,8 @@ if __name__ == '__main__':
         drop_list.append('{}_{}'.format(bname, SYEAR))
     extrapolated_benefit = ben.benefit_extrapolation.drop(drop_list, axis=1)
     # drop records with no benefits and write to file
-    col_list = extrapolated_benefit.columns
-    mask = extrapolated_benefit.loc[:, col_list != 'RECID'].sum(1)
+    column_list = extrapolated_benefit.columns
+    mask = extrapolated_benefit.loc[:, column_list != 'RECID'].sum(1)
     gets_benefits = deepcopy(extrapolated_benefit[mask != 0])
     integer_gets_benefits = gets_benefits.astype(np.int32)
     integer_gets_benefits.to_csv('cps_benefits.csv.gz', index=False,


### PR DESCRIPTION
This pull request makes changes that allow the `extrapolation.py` script to run to completion and to pass the taxdata repo's code-style test.  The first commit in this PR increases the relative tolerance (for an acceptable extrapolation) from 0.01 to 0.05, which allows the script to run to completion.  The second commit eliminates several pycodestyle (nee PEP8) [warnings](https://github.com/open-source-economics/taxdata/issues/232#issuecomment-399711170) such as line too long, too many spaces, and ambiguous variable name.  The changes in the second commit in this PR produce exactly the same `cps_benefits.csv.gz` file as the first commit produced, confirming that the changes in the second commit are purely cosmetic.

However, the contents of the new `cps_benefits.csv.gz` file produced with this code are substantially different from the contents of the `cps_benefits.csv.gz` file on the taxdata master branch (which is currently being used in Tax-Calculator).  The next step is to determine if this new `cps_benefits.csv.gz` file has sensible content.  We plan to do that by using it (and other more current taxdata made files) in the kind of "test" described in taxdata issue #241.

@hdoupe and @andersonfrailey, I'd appreciate it if you could review these changes.

Also, @hdoupe, I need your direction on how to handle the pandas warning described at the bottom of [this 232 comment](https://github.com/open-source-economics/taxdata/issues/232#issuecomment-399711170).