### PR TITLE
Add benefit test that compares actual and target benefit amounts/counts

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,4 +124,4 @@ def puf_benefits(test_path):
 @pytest.fixture(scope='session')
 def growth_rates(test_path):
     gr_path = os.path.join(test_path, '../cps_stage4/growth_rates.csv')
-    return pd.read_csv(gr_path)
+    return pd.read_csv(gr_path, index_col=0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import pandas as pd
 CPS_START_YEAR = 2014
 PUF_START_YEAR = 2011
 PUF_COUNT = 239002
+LAST_YEAR = 2027
 
 
 @pytest.fixture(scope='session')
@@ -78,6 +79,11 @@ def puf_start_year():
 
 
 @pytest.fixture(scope='session')
+def last_year():
+    return LAST_YEAR
+
+
+@pytest.fixture(scope='session')
 def cps_weights(test_path):
     cpsw_path = os.path.join(test_path, '../cps_stage2/cps_weights.csv.gz')
     return pd.read_csv(cpsw_path)
@@ -113,3 +119,9 @@ def puf_benefits(test_path):
     # pufb_path = os.path.join(test_path, '../puf_stage4/puf_benefits.csv.gz')
     # return pd.read_csv(pufb_path)
     return None
+
+
+@pytest.fixture(scope='session')
+def growth_rates(test_path):
+    gr_path = os.path.join(test_path, '../cps_stage4/growth_rates.csv')
+    return pd.read_csv(gr_path)

--- a/tests/test_benefits.py
+++ b/tests/test_benefits.py
@@ -87,7 +87,8 @@ def test_extrapolated_benefits(kind, cps_benefits, puf_benefits,
     Compare actual and target extrapolated benefit amounts and counts.
     (Note that there are no puf_benefits data.)
     """
-    rel_tolerance = 0.15  # should be not much more than 0.05
+    rtol_amt = 0.13
+    rtol_cnt = 0.15
     dump_res = False
     # specify several DataFrames and related parameters
     if kind == 'cps':
@@ -175,7 +176,7 @@ def test_extrapolated_benefits(kind, cps_benefits, puf_benefits,
         for bname in benefit_names:
             if not np.allclose([actual_amount[bname]],
                                [target_amount[bname]],
-                               atol=0.0, rtol=rel_tolerance):
+                               atol=0.0, rtol=rtol_amt):
                 differences = True
                 reldiff = actual_amount[bname] / target_amount[bname] - 1.0
                 msg = '{} {}\tAMT\t{:9.3f}{:9.3f}{:8.1f}'
@@ -185,7 +186,7 @@ def test_extrapolated_benefits(kind, cps_benefits, puf_benefits,
                                  reldiff * 100))
             if not np.allclose([actual_count[bname]],
                                [target_count[bname]],
-                               atol=0.0, rtol=rel_tolerance):
+                               atol=0.0, rtol=rtol_cnt):
                 differences = True
                 reldiff = actual_count[bname] / target_count[bname] - 1.0
                 msg = '{} {}\tCNT\t{:9.3f}{:9.3f}{:8.1f}'


### PR DESCRIPTION
This pull request adds a benefit test that tries to do the same comparison as was done in issue #241: that is, compare actual aggregate benefit amounts and counts (filing units receiving the benefit) with target benefit amounts and counts for each year after the start year.  The target amounts/counts are the start year amounts/counts blown-up by the factors in the `cps_stage4/growth_rates.csv` file.  The actual amounts/counts are derived from the extrapolated-benefit information in the `cps_stage4/cps_benefits.csv.gz` file.  All the amounts and counts are weighted.

The new test was developed off the master branch (before pull request #242 was merged), so the results of the new test are difficult to interpret.   The plan is that after this pull request has been reviewed and merged, the new master branch will be merged into pull request #242.  Only then will the test results provide guidance on the quality of the extrapolated benefits.

Right now, in order to make the new test pass, the relative tolerance for actual-vs-target differences has to be set to a 0.15 value.  Hopefully, when the new test is merged into pending pull request #242, the new test will pass when assuming a much lower value for the relative tolerance.

@andersonfrailey @hdoupe @MattHJensen 

