### PR TITLE
Reduce rtol_amt and rtol_cnt in test_extrapolated_benefits

### DIFF
--- a/tests/test_benefits.py
+++ b/tests/test_benefits.py
@@ -87,8 +87,8 @@ def test_extrapolated_benefits(kind, cps_benefits, puf_benefits,
     Compare actual and target extrapolated benefit amounts and counts.
     (Note that there are no puf_benefits data.)
     """
-    rtol_amt = 0.13
-    rtol_cnt = 0.15
+    rtol_amt = 0.002
+    rtol_cnt = 0.10
     dump_res = False
     # specify several DataFrames and related parameters
     if kind == 'cps':


### PR DESCRIPTION
This pull request reduces to the lowest possible values the `rtol_amt` and `rtol_cnt` relative tolerances for actual-vs-target comparisons for benefit dollar amounts and benefit recipient counts.  By lowest possible, we mean that lower values will cause the test to fail.  
The new lower values are `rtol_amt = 0.002` and `rtol_cnt = 0.10`

If we temporarily set `rtol_cnt = 0.05`, which is what it should be given the current version of the `cps_stage4/extrapolation.py` script, there are many test failures.  Here is a list of the test failures:
```
--------------------------------------------------
TEST RESULTS WITH rtol_amt=0.002 and rtol_cnt=0.05
--------------------------------------------------
2015 ssi	CNT	    6.448    6.815    -5.4
2015 snap	CNT	   25.292   27.968    -9.6
2016 mcaid	CNT	   29.175   30.949    -5.7
2017 mcaid	CNT	   29.674   31.505    -5.8
2018 mcaid	CNT	   30.175   32.063    -5.9
2018 tanf	CNT	    3.101    2.930     5.8
2019 mcaid	CNT	   30.680   32.576    -5.8
2019 tanf	CNT	    3.145    2.930     7.3
2019 housing	CNT	    4.236    4.473    -5.3
2020 mcaid	CNT	   31.165   33.093    -5.8
2021 mcaid	CNT	   31.638   33.519    -5.6
2021 housing	CNT	    4.146    4.407    -5.9
2022 mcaid	CNT	   32.118   33.949    -5.4
2022 tanf	CNT	    3.095    2.930     5.6
2022 vet	CNT	    4.848    4.608     5.2
2023 mcaid	CNT	   32.598   34.334    -5.1
2023 snap	CNT	   25.572   27.022    -5.4
2023 tanf	CNT	    3.131    2.930     6.9
2023 housing	CNT	    4.072    4.342    -6.2
2024 tanf	CNT	    3.170    2.930     8.2
2025 wic	CNT	    4.884    4.620     5.7
2025 vet	CNT	    4.880    4.628     5.4
2025 housing	CNT	    4.013    4.277    -6.2
2027 snap	CNT	   25.233   27.022    -6.6
2027 tanf	CNT	    3.082    2.930     5.2
--------------------------------------------------
```
The largest count deviation is for the SNAP program in 2015 where the target recipient count is 27.968 million filing units and the actual count is 25.292 million filing units, which is about **9.6 percent below the target**.  Another example is 2024 TANF for which the actual count is about **8.2 percent above the target**.

Perhaps there is a problem with the new test, which is in the `test_benefits.py` file.  If the test is sensible, then these test results suggest that there are problems with the dual-benefit-targets algorithm implemented in the two Python scripts in  the`cps_stage4` directory.  I say that because the `extrapolation.py` script has as an explicit objective producing count deviations of no more the five percent.

