### PR TITLE
Experiment with no benefit-count targeting [DON'T MERGE]

### DIFF
--- a/cps_stage4/extrapolation.py
+++ b/cps_stage4/extrapolation.py
@@ -272,7 +272,7 @@ if __name__ == '__main__':
     # create extrapolated benefits
     ben = Benefits()
     for _ in range(SYEAR, LYEAR):
-        ben.increment_year(tol=0.05)
+        ben.increment_year(tol=9e99)
     # drop unnecessary variables
     drop_list = []
     # drop all recipient columns

--- a/puf_stage3/stage3.py
+++ b/puf_stage3/stage3.py
@@ -3,16 +3,16 @@ import numpy as np
 import pandas as pd
 
 
-def adjustment(agi, var, var_name, target, weight, blowup):
+def adjustment(agi, var, var_name, target, weights, blowup):
     """
     Parameters
     ----------
     agi: AGI provided in PUF
-    var: Variable being adjusted
-    var_name: Three letter code to identify variable being adjusted
-    target: Target bin levels
-    weight: Weights file
-    blowup: Blowup factors created in Stage 1 of the extrapolation process
+    var: variable being adjusted
+    var_name: three letter code to identify variable being adjusted
+    target: target bin levels
+    weights: integer*100 weights dataframe
+    blowup: blowup factors created in Stage 1 of the extrapolation process
 
     Returns
     -------
@@ -24,7 +24,7 @@ def adjustment(agi, var, var_name, target, weight, blowup):
     goal_total = pd.DataFrame()
     for year in range(2011, 2028):
         wt_year = 'WT{}'.format(year)
-        s006 = weight[wt_year] * 0.01
+        s006 = weights[wt_year] * 0.01
         var_copy *= blowup[year]
         total = (var_copy * s006).sum()
         goal_total[year] = [total]
@@ -47,7 +47,7 @@ def adjustment(agi, var, var_name, target, weight, blowup):
         goal_amts = goal_total[year][0] * distribution[year]
 
         wt_year = 'WT{}'.format(year)
-        s006 = weight[wt_year] * 0.01
+        s006 = weights[wt_year] * 0.01
         var = var * blowup[year]
         # Find current total in each bin
         bin_0 = np.where(agi < 0,

--- a/tests/test_benefits.py
+++ b/tests/test_benefits.py
@@ -87,8 +87,8 @@ def test_extrapolated_benefits(kind, cps_benefits, puf_benefits,
     Compare actual and target extrapolated benefit amounts and counts.
     (Note that there are no puf_benefits data.)
     """
-    rtol_amt = 0.13
-    rtol_cnt = 0.15
+    rtol_amt = 0.002
+    rtol_cnt = 0.10
     dump_res = False
     # specify several DataFrames and related parameters
     if kind == 'cps':

--- a/tests/test_benefits.py
+++ b/tests/test_benefits.py
@@ -76,7 +76,7 @@ def test_benefits(kind, cps_benefits, puf_benefits,
         msg = 'number {} records with all zero benefits in every year = {}'
         raise ValueError(msg.format(kind, num_allzeros))
 
-
+@pytest.mark.one
 @pytest.mark.parametrize('kind', ['cps'])
 def test_extrapolated_benefits(kind, cps_benefits, puf_benefits,
                                cps, puf, cps_weights, puf_weights,
@@ -88,7 +88,7 @@ def test_extrapolated_benefits(kind, cps_benefits, puf_benefits,
     (Note that there are no puf_benefits data.)
     """
     rtol_amt = 0.002
-    rtol_cnt = 0.10
+    rtol_cnt = 0.05
     dump_res = False
     # specify several DataFrames and related parameters
     if kind == 'cps':

--- a/tests/test_benefits.py
+++ b/tests/test_benefits.py
@@ -88,7 +88,7 @@ def test_extrapolated_benefits(kind, cps_benefits, puf_benefits,
     (Note that there are no puf_benefits data.)
     """
     rtol_amt = 0.002
-    rtol_cnt = 0.05
+    rtol_cnt = 0.0
     dump_res = False
     # specify several DataFrames and related parameters
     if kind == 'cps':

--- a/tests/test_benefits.py
+++ b/tests/test_benefits.py
@@ -76,7 +76,8 @@ def test_benefits(kind, cps_benefits, puf_benefits,
         msg = 'number {} records with all zero benefits in every year = {}'
         raise ValueError(msg.format(kind, num_allzeros))
 
-@pytest.mark.one
+
+@pytest.mark.extrapolated_benefits
 @pytest.mark.parametrize('kind', ['cps'])
 def test_extrapolated_benefits(kind, cps_benefits, puf_benefits,
                                cps, puf, cps_weights, puf_weights,
@@ -87,8 +88,8 @@ def test_extrapolated_benefits(kind, cps_benefits, puf_benefits,
     Compare actual and target extrapolated benefit amounts and counts.
     (Note that there are no puf_benefits data.)
     """
-    rtol_amt = 0.002
-    rtol_cnt = 0.0
+    rtol_amt = -0.002
+    rtol_cnt = -0.10
     dump_res = False
     # specify several DataFrames and related parameters
     if kind == 'cps':


### PR DESCRIPTION
This pull request is an experiment that is not really intended for merging into the taxdata master branch.
What this branch does is generate extrapolated benefits when the benefit-count targeting logic is turned off.
The point of this experiment is to compare the extrapolated benefit counts in two different cases: 
1. when benefit counts are targeted (which is the case on the taxdata master branch) in the `cps_stage4/extrapolation.py` script, and
2. when they are not targeted in the `cps_stage4/extrapolation.py` script.

Note that the code changes in this pull request are intentionally causing `test_extrapolated_benefits` to fail.

I will post other comments in this pull request that show the results of this experiment.