### PR TITLE
Revise benefit test so that filing-unit "participants" can be XTOT or one

### DIFF
--- a/tests/test_benefits.py
+++ b/tests/test_benefits.py
@@ -76,7 +76,7 @@ def test_benefits(kind, cps_benefits, puf_benefits,
         msg = 'number {} records with all zero benefits in every year = {}'
         raise ValueError(msg.format(kind, num_allzeros))
 
-@pytest.mark.one
+
 @pytest.mark.parametrize('kind', ['cps'])
 def test_extrapolated_benefits(kind, cps_benefits, puf_benefits,
                                cps, puf, cps_weights, puf_weights,
@@ -88,12 +88,12 @@ def test_extrapolated_benefits(kind, cps_benefits, puf_benefits,
     (Note that there are no puf_benefits data.)
     """
     # specify nature of counts
-    size_is_xtot = False
+    size_is_xtot = True
     # ... True implies size is XTOT (i.e., individual counts)
     # ... False implies size is one (i.e., filing-unit counts)
     # specify maximum relative tolerances allowed to avoid test failure
     rtol_amt = 0.002
-    rtol_cnt = 0.0  # ... 0.10
+    rtol_cnt = 0.12
     # specify several DataFrames and related parameters
     if kind == 'cps':
         basedata = cps

--- a/tests/test_benefits.py
+++ b/tests/test_benefits.py
@@ -87,7 +87,7 @@ def test_extrapolated_benefits(kind, cps_benefits, puf_benefits,
     Compare actual and target extrapolated benefit amounts and counts.
     (Note that there are no puf_benefits data.)
     """
-    # specify nature of counts
+    # specify nature of counts (benefit recipients are in the [1,XTOT] range)
     size_is_xtot = True
     # ... True implies size is XTOT (i.e., individual counts)
     # ... False implies size is one (i.e., filing-unit counts)

--- a/tests/test_benefits.py
+++ b/tests/test_benefits.py
@@ -134,7 +134,7 @@ def test_extrapolated_benefits(kind, cps_benefits, puf_benefits,
         ben = basedata['{}_ben'.format(bname)]
         benamt = (ben * wght).sum() * 1e-9
         fyr_amount[bname] = round(benamt, 3)
-        bencnt = (size * wght[ben > 0]).sum() * 1e-6
+        bencnt = (size[ben > 0] * wght[ben > 0]).sum() * 1e-6
         fyr_count[bname] = round(bencnt, 3)
         msg = '{} {}\tAMT\t{:9.3f}'
         print(msg.format(first_year, bname, fyr_amount[bname]))
@@ -152,7 +152,7 @@ def test_extrapolated_benefits(kind, cps_benefits, puf_benefits,
             assert len(ben.index) == len(wght.index)
             benamt = (ben * wght).sum() * 1e-9
             actual_amount[bname] = round(benamt, 3)
-            bencnt = (size * wght[ben > 0]).sum() * 1e-6
+            bencnt = (size[ben > 0] * wght[ben > 0]).sum() * 1e-6
             actual_count[bname] = round(bencnt, 3)
         # compute target amuonts/counts for year
         target_amount = dict()


### PR DESCRIPTION
This pull request generalizes the new extrapolated benefit test that was added in pull request #246 and modified in pull requests #248 and #250.  Prior versions of `test_extrapolated_benefits` assumed that the participant counts were filing units rather than individuals.  The problem for testing is that there is no information in the `cps_benefits.csv.gz` file about how many individuals in each filing unit are benefit-program participants.  The actual number of participants is obviously somewhere in the [1, `XTOT`] range.

The test revisions in this pull request add a `size_is_xtot` boolean switch that sets the number of benefit-program participants in each filing unit to one (when `size_is_xtot == False`) or to `XTOT` (when `size_is_xtot == True`).  When `size_is_xtot == True` and `rtol_cnt == 0.05` (rather than its normal value of 0.12), the test produces these results:
```
--------------------------------------------------
TEST RESULTS WITH rtol_amt=0.002 and rtol_cnt=0.05
                  and size_is_xtot=True
--------------------------------------------------
2015 mcare	CNT	   67.018   63.651     5.3
2015 tanf	CNT	    6.679    6.111     9.3
2016 ssi	CNT	   13.957   13.087     6.6
2016 wic	CNT	   17.639   16.547     6.6
2016 tanf	CNT	    8.073    7.479     7.9
2016 housing	CNT	    9.232    8.640     6.9
2017 ssi	CNT	   13.800   13.061     5.7
2017 snap	CNT	   52.647   49.634     6.1
2017 tanf	CNT	    8.166    7.479     9.2
2018 ssi	CNT	   14.114   13.061     8.1
2018 snap	CNT	   53.461   49.634     7.7
2018 tanf	CNT	    8.255    7.479    10.4
2018 housing	CNT	    8.998    8.460     6.4
2019 tanf	CNT	    8.351    7.479    11.7
2020 ssi	CNT	   14.009   13.192     6.2
2020 mcare	CNT	   77.593   73.778     5.2
2020 snap	CNT	   52.494   49.634     5.8
2020 tanf	CNT	    8.032    7.479     7.4
2020 housing	CNT	    8.898    8.334     6.8
2021 ssi	CNT	   14.359   13.244     8.4
2021 mcare	CNT	   79.975   75.927     5.3
2021 snap	CNT	   53.296   49.634     7.4
2021 tanf	CNT	    8.119    7.479     8.6
2022 mcare	CNT	   82.405   78.100     5.5
2022 snap	CNT	   54.100   49.634     9.0
2022 tanf	CNT	    8.187    7.479     9.5
2022 vet	CNT	    9.413    8.877     6.0
2022 housing	CNT	    8.801    8.211     7.2
2023 ssi	CNT	   14.193   13.401     5.9
2023 mcare	CNT	   84.794   80.218     5.7
2023 wic	CNT	   17.397   16.548     5.1
2023 tanf	CNT	    8.262    7.479    10.5
2024 ssi	CNT	   14.518   13.506     7.5
2024 mcare	CNT	   87.116   82.286     5.9
2024 snap	CNT	   52.778   49.634     6.3
2024 wic	CNT	   17.513   16.548     5.8
2024 tanf	CNT	    8.342    7.479    11.5
2024 housing	CNT	    8.669    8.088     7.2
2025 mcare	CNT	   89.507   84.378     6.1
2025 snap	CNT	   53.531   49.634     7.9
2025 wic	CNT	   17.638   16.548     6.6
2025 tanf	CNT	    7.942    7.479     6.2
2026 ssi	CNT	   14.559   13.677     6.4
2026 mcare	CNT	   91.720   86.434     6.1
2026 snap	CNT	   54.243   49.634     9.3
2026 tanf	CNT	    8.014    7.479     7.2
2027 ssi	CNT	   14.846   13.677     8.5
2027 mcare	CNT	   93.762   86.434     8.5
2027 snap	CNT	   52.299   49.634     5.4
2027 tanf	CNT	    8.078    7.479     8.0
2027 housing	CNT	    8.345    7.909     5.5
```
Compare the above results with those produced with `size_is_xtot == False` which were reported [here](https://github.com/open-source-economics/taxdata/pull/248#issue-201037335).