### PR TITLE
Add unique_recid test to tests/test_data.py

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -6,6 +6,24 @@ import pytest
 import numpy as np
 
 
+def unique_recid(data, dataname):
+    """
+    Test that RECID values are unique.
+    """
+    recid = data['RECID']
+    unique, counts = np.unique(recid, return_counts=True)
+    recid_count = dict(zip(unique, counts))
+    duplicates = False
+    msg = ''
+    for rid in sorted(recid_count.keys()):
+        if recid_count[rid] > 1:
+            duplicates = True
+            msg += '\nRECID={} has COUNT={}'.format(rid, recid_count[rid])
+    if duplicates:
+        title = 'The following {} RECIDs have COUNTS greater than one:'
+        raise ValueError(title.format(dataname) + msg)
+
+
 def min_max(data, meta, dataname):
     """
     Test that variable variables are within their minimum/maximu range.
@@ -145,6 +163,7 @@ def test_pufcsv_data(puf, metadata, test_path):
     """
     Test PUF data.
     """
+    unique_recid(puf, 'PUF')
     min_max(puf, metadata, 'puf')
     relationships(puf, 'PUF')
     variable_check(test_path, puf, 'puf')
@@ -154,6 +173,7 @@ def test_cpscsv_data(cps, metadata, test_path):
     """
     Test CPS data.
     """
+    unique_recid(cps, 'CPS')
     min_max(cps, metadata, 'cps')
     relationships(cps, 'CPS')
     variable_check(test_path, cps, 'cps')


### PR DESCRIPTION
This pull request adds a test that checks that RECID values are unique.
The `cps.csv.gz` file passes this new test, but the `puf.csv` file fails the test.

Here are the LOCAL pytest results on this branch:
```
iMac2:taxdata mrh$ git checkout  add-recid-test
Switched to branch 'add-recid-test'

iMac2:taxdata mrh$ make pytest
============================= test session starts ==============================
platform darwin -- Python 2.7.15, pytest-3.4.2, py-1.5.2, pluggy-0.6.0
rootdir: /Users/mrh/work/OSPC/taxdata, inifile:
plugins: xdist-1.22.1, forked-0.2
gw0 [11] / gw1 [11] / gw2 [11] / gw3 [11]
scheduling tests via LoadScheduling
F......ss..                                                              [100%]
=================================== FAILURES ===================================
_______________________________ test_pufcsv_data _______________________________
[gw1] darwin -- Python 2.7.15 /Users/mrh/anaconda/bin/python

puf =         DSI  e00200  e00300  e00400   ...    k1bx14p  k1bx14s  agi_bin  g20500...       0   ...          0        0        1       0

[239002 rows x 87 columns]
metadata = {'DSI': {'availability': 'taxdata_puf, taxdata_cps', 'desc': '1 if claimed as dependent on another return; otherwise 0...te, 4=household-head, 5=widow(er)]', 'form': {'2013-2016': '1040 lines 1-5'}, 'range': {'max': 5, 'min': 1}, ...}, ...}
test_path = '/Users/mrh/work/OSPC/taxdata/tests'

    @pytest.mark.requires_pufcsv
    def test_pufcsv_data(puf, metadata, test_path):
        """
        Test PUF data.
        """
>       unique_recid(puf, 'PUF')

tests/test_data.py:166: 

... [SNIP] ...

E           ValueError: The following PUF RECIDs have COUNTS greater than one:
E           RECID=4000000 has COUNT=2
E           RECID=4000010 has COUNT=2
E           RECID=4000030 has COUNT=2
E           RECID=4000040 has COUNT=2
E           RECID=4000060 has COUNT=2
E           RECID=4000070 has COUNT=2
E           RECID=4000080 has COUNT=2
E           RECID=4000090 has COUNT=2
E           RECID=4000110 has COUNT=2
E           RECID=4000150 has COUNT=2
E           RECID=4000160 has COUNT=2
E           RECID=4000220 has COUNT=2
E           RECID=4000240 has COUNT=2
E           RECID=4000241 has COUNT=2
E           RECID=4000250 has COUNT=2
E           RECID=4000270 has COUNT=2
E           RECID=4000310 has COUNT=2
E           RECID=4000320 has COUNT=2
E           RECID=4000340 has COUNT=2
E           RECID=4000350 has COUNT=2
E           RECID=4000390 has COUNT=2
E           RECID=4000420 has COUNT=2
E           RECID=4000430 has COUNT=2
E           RECID=4000440 has COUNT=2
E           RECID=4000450 has COUNT=2
E           RECID=4000460 has COUNT=2
E           RECID=4000480 has COUNT=2
E           RECID=4000490 has COUNT=2
E           RECID=4000500 has COUNT=2
E           RECID=4000540 has COUNT=2
E           RECID=4000550 has COUNT=2
E           RECID=4000580 has COUNT=2
E           RECID=4000600 has COUNT=2
E           RECID=4000601 has COUNT=2
E           RECID=4000640 has COUNT=2
E           RECID=4000670 has COUNT=2
E           RECID=4000680 has COUNT=2
E           RECID=4000740 has COUNT=2
E           RECID=4000770 has COUNT=2
E           RECID=4000790 has COUNT=2
E           RECID=4000791 has COUNT=2
E           RECID=4000800 has COUNT=2
E           RECID=4000810 has COUNT=2
E           RECID=4000811 has COUNT=2
E           RECID=4000840 has COUNT=2
E           RECID=4000850 has COUNT=2
E           RECID=4000851 has COUNT=2
E           RECID=4000860 has COUNT=2
E           RECID=4000880 has COUNT=2
E           RECID=4000930 has COUNT=2
E           RECID=4001100 has COUNT=2
E           RECID=4001110 has COUNT=2
E           RECID=4001120 has COUNT=2
E           RECID=4001270 has COUNT=2
E           RECID=4004160 has COUNT=2
E           RECID=4004190 has COUNT=2
E           RECID=4004240 has COUNT=2
E           RECID=4004340 has COUNT=2
E           RECID=4004410 has COUNT=2
E           RECID=4004530 has COUNT=2
E           RECID=4004690 has COUNT=2
E           RECID=4004750 has COUNT=2
E           RECID=4004760 has COUNT=2
E           RECID=4004880 has COUNT=2
E           RECID=4005540 has COUNT=2
E           RECID=4005600 has COUNT=2
E           RECID=4005620 has COUNT=2
E           RECID=4005760 has COUNT=2
E           RECID=4005880 has COUNT=2
E           RECID=4005910 has COUNT=2
E           RECID=4005960 has COUNT=2
E           RECID=4006120 has COUNT=2
E           RECID=4006130 has COUNT=2
E           RECID=4006200 has COUNT=2
E           RECID=4006380 has COUNT=2
E           RECID=4006390 has COUNT=2
E           RECID=4006500 has COUNT=2
E           RECID=4006501 has COUNT=2
E           RECID=4006640 has COUNT=2
E           RECID=4006660 has COUNT=2
E           RECID=4006790 has COUNT=2
E           RECID=4006860 has COUNT=2
E           RECID=4006980 has COUNT=2
E           RECID=4006990 has COUNT=2
E           RECID=4007040 has COUNT=2
E           RECID=4007120 has COUNT=2

tests/test_data.py:24: ValueError
================ 1 failed, 8 passed, 2 skipped in 23.64 seconds ================
make: *** [pytest] Error 1
```