### PR TITLE
Expand scope of Makefile to include puf_data/StatMatch/Matching logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ __pycache__/
 # Mac OS X
 *.DS_Store
 
-# IRS-SOI PUF data files
+# IRS-SOI PUF and related CPS matching data files
 puf_data/puf.csv
 puf_data/cps-matched-puf.csv
+puf_data/StatMatch/Matching/puf2011.csv
+puf_data/StatMatch/Matching/cpsmar2016.csv

--- a/Makefile
+++ b/Makefile
@@ -79,12 +79,12 @@ puf-files: puf_data/puf.csv \
            puf_stage3/puf_ratios.csv
 
 PM_DIR=./puf_data/StatMatch/Matching
-PM_FILES := $(shell ls -l $(PM_DIR)/*py | awk '{print $$9}')
-puf_data/cps-matched-puf.csv: $(PM_FILES) \
+PM_PY_FILES := $(shell ls -l $(PM_DIR)/*py | awk '{print $$9}')
+puf_data/cps-matched-puf.csv: $(PM_PY_FILES) \
                               $(PM_DIR)/puf2011.csv \
 #                              $(PM_DIR)/cpsmar2016.csv
 	@echo $(PM_DIR)
-	@echo $(PM_FILES)
+	@echo $(PM_PY_FILES)
 #	cd $(PM_DIR) ; python runmatch.py
 
 puf_data/puf.csv: puf_data/finalprep.py \

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ PM_PY_FILES := $(shell ls -l $(PM_DIR)/*py | awk '{print $$9}')
 puf_data/cps-matched-puf.csv: $(PM_PY_FILES) \
                               $(PM_DIR)/puf2011.csv \
                               $(PM_DIR)/cpsmar2016.csv
-	cd $(PM_DIR) ; python runmatch.py -c cpsmar2016.csv
+	cd $(PM_DIR) ; python runmatch.py
 
 puf_data/puf.csv: puf_data/finalprep.py \
                   puf_data/cps-matched-puf.csv

--- a/Makefile
+++ b/Makefile
@@ -82,10 +82,8 @@ PM_DIR=./puf_data/StatMatch/Matching
 PM_PY_FILES := $(shell ls -l $(PM_DIR)/*py | awk '{print $$9}')
 puf_data/cps-matched-puf.csv: $(PM_PY_FILES) \
                               $(PM_DIR)/puf2011.csv \
-#                              $(PM_DIR)/cpsmar2016.csv
-	@echo $(PM_DIR)
-	@echo $(PM_PY_FILES)
-#	cd $(PM_DIR) ; python runmatch.py
+                              $(PM_DIR)/cpsmar2016.csv
+	cd $(PM_DIR) ; python runmatch.py
 
 puf_data/puf.csv: puf_data/finalprep.py \
                   puf_data/cps-matched-puf.csv

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ PM_PY_FILES := $(shell ls -l $(PM_DIR)/*py | awk '{print $$9}')
 puf_data/cps-matched-puf.csv: $(PM_PY_FILES) \
                               $(PM_DIR)/puf2011.csv \
                               $(PM_DIR)/cpsmar2016.csv
-	cd $(PM_DIR) ; python runmatch.py
+	cd $(PM_DIR) ; python runmatch.py -c cpsmar2016.csv
 
 puf_data/puf.csv: puf_data/finalprep.py \
                   puf_data/cps-matched-puf.csv

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,15 @@ puf-files: puf_data/puf.csv \
            puf_stage2/puf_weights.csv.gz \
            puf_stage3/puf_ratios.csv
 
+PM_DIR=./puf_data/StatMatch/Matching
+PM_FILES := $(shell ls -l $(PM_DIR)/*py | awk '{print $$9}')
+puf_data/cps-matched-puf.csv: $(PM_FILES) \
+                              $(PM_DIR)/puf2011.csv \
+#                              $(PM_DIR)/cpsmar2016.csv
+	@echo $(PM_DIR)
+	@echo $(PM_FILES)
+#	cd $(PM_DIR) ; python runmatch.py
+
 puf_data/puf.csv: puf_data/finalprep.py \
                   puf_data/cps-matched-puf.csv
 	cd puf_data ; python finalprep.py

--- a/puf_data/StatMatch/Matching/__init__.py
+++ b/puf_data/StatMatch/Matching/__init__.py
@@ -1,4 +1,0 @@
-from .adj_filst import *
-from .cpsmar import *
-from .cps_rets import *
-from .soi_rets import *

--- a/puf_data/StatMatch/Matching/add_nonfilers.py
+++ b/puf_data/StatMatch/Matching/add_nonfilers.py
@@ -266,7 +266,6 @@ def add_nonfiler(cpsrets, nonfiler):
     # weight
     nonfiler['matched_weight'] = wt
 
-    final = pd.concat([cpsrets, nonfiler], ignore_index=True)
+    final = pd.concat([cpsrets, nonfiler], sort=True, ignore_index=True)
     final['finalseq'] = final.index + 1
-    # final.to_csv('prod2009_v2.csv', index=False)
     return final

--- a/puf_data/StatMatch/Matching/runmatch.py
+++ b/puf_data/StatMatch/Matching/runmatch.py
@@ -85,4 +85,5 @@ def match(mar_cps_path='asec2016_pubuse_v3.dat',
 
 if __name__ == "__main__":
     cps_matched = match()
-    cps_matched.to_csv('../../cps-matched-puf.csv', index=False)
+    cps_matched.to_csv('../../cps-matched-puf.csv', index=False,
+                       float_format='%.2f')


### PR DESCRIPTION
This pull request adds `puf_data/cps-matched-puf.csv` as a target with its own dependencies and recipe.