### PR TITLE
Remove arguments from runmatch.py

### DIFF
--- a/puf_data/StatMatch/Matching/runmatch.py
+++ b/puf_data/StatMatch/Matching/runmatch.py
@@ -29,7 +29,7 @@ def match():
         else:
             m = ('You must have either the .DAT or .CSV version of the 2016' +
                  ' CPS in your directory')
-            raise IOError(m)
+            raise OSError(m)
     print('Reading PUF Data')
     puf_path = 'puf2011.csv'
     puf = pd.read_csv(puf_path)

--- a/puf_data/StatMatch/Matching/runmatch.py
+++ b/puf_data/StatMatch/Matching/runmatch.py
@@ -29,7 +29,7 @@ def match():
         else:
             m = ('You must have either the .DAT or .CSV version of the 2016' +
                  ' CPS in your directory')
-            raise OSError(m)
+            raise FileNotFoundError(m)
     print('Reading PUF Data')
     puf_path = 'puf2011.csv'
     puf = pd.read_csv(puf_path)


### PR DESCRIPTION
This PR updates `runmatch.py` so that instead of a user specifying the path to input files the program checks for the files automatically. If the CSV version of the appropriate CPS file is found, it will read that in. If there is no CSV file but there is a .DAT version, it will create the CPS from the .DAT file. Otherwise an error is raised.

I chose to raise an OSError because, according to the Python [docs](https://docs.python.org/3/library/exceptions.html#OSError),
>This exception is raised when a system function returns a system-related error, including I/O failures such as “file not found”

cc @martinholmer 