### PR TITLE
Eliminate spaces on blank line in cps_data/finalprep.py

### DIFF
--- a/cps_data/finalprep.py
+++ b/cps_data/finalprep.py
@@ -67,7 +67,7 @@ def main():
         'ELDERLY_DEPENDENT': 'elderly_dependents',
         'F2441': 'f2441'
     }
-    
+
     data = data.rename(columns=renames)
     data['MARS'] = np.where(data.JS == 3, 4, data.JS)
     data['EIC'] = np.minimum(3, data.EIC)


### PR DESCRIPTION
This cosmetic change eliminates a `pycodestyle` warning generated by `make cstest`.