### PR TITLE
Add inPUF variable to puf.csv file

### DIFF
--- a/puf_data/StatMatch/Matching/runmatch.py
+++ b/puf_data/StatMatch/Matching/runmatch.py
@@ -38,10 +38,12 @@ def match():
     # Remove aggregated variables from the PUF
     puf = puf[(puf['recid'] != 999996) & (puf['recid'] != 999997) &
               (puf['recid'] != 999998) & (puf['recid'] != 999999)]
+    puf['inPUF'] = 1
 
     print('Creating CPS Tax Units')
     rets = Returns(mar_cps)
     cps = rets.computation()
+    cps['inPUF'] = 0
 
     print('CPS Tax Units Created')
     filers, nonfilers = adjfilst(cps)


### PR DESCRIPTION
This pull request adds a new variable to the `puf.csv` file.  The new variable is called `inPUF` and it is an integer variable with a value of either 1 (indicating that the `puf.csv` record is from the IRS/SOI PUF) or 0 (indicating that the `puf.csv` record is from the CPS).  This new variable is not used in Tax-Calculator logic, but will be useful in taxdata variable imputation work.